### PR TITLE
#136 : AbilityGroup added to calculate learned abilities for PC

### DIFF
--- a/Datas/Admins/sinac.json
+++ b/Datas/Admins/sinac.json
@@ -1344,6 +1344,7 @@
           "Rating": 1
         }
       ],
+      "LearnedAbilityGroups": [],
       "Conditions": {
         "Drunk": 0,
         "Full": 24,
@@ -3126,6 +3127,7 @@
           "Rating": 1
         }
       ],
+      "LearnedAbilityGroups": [],
       "Conditions": {
         "Drunk": 0,
         "Full": 6,
@@ -3470,7 +3472,474 @@
       }
     },
     {
-      "CreationTime": "2025-12-05T23:37:49.4335981+01:00",
+      "CreationTime": "2025-12-07T00:41:18.0014667+01:00",
+      "RoomId": 3721,
+      "SilverCoins": 91,
+      "GoldCoins": 0,
+      "Experience": 1232,
+      "Alignment": 0,
+      "Trains": 1,
+      "Practices": 7,
+      "AutoFlags": 127,
+      "CurrentQuests": [],
+      "LearnedAbilities": [
+        {
+          "Name": "sword",
+          "ResourceKind": null,
+          "CostAmount": 0,
+          "CostAmountOperator": 0,
+          "Level": 1,
+          "Learned": 40,
+          "Rating": 2
+        },
+        {
+          "Name": "scrolls",
+          "ResourceKind": null,
+          "CostAmount": 0,
+          "CostAmountOperator": 0,
+          "Level": 1,
+          "Learned": 0,
+          "Rating": 8
+        },
+        {
+          "Name": "staves",
+          "ResourceKind": null,
+          "CostAmount": 0,
+          "CostAmountOperator": 0,
+          "Level": 1,
+          "Learned": 0,
+          "Rating": 8
+        },
+        {
+          "Name": "wands",
+          "ResourceKind": null,
+          "CostAmount": 0,
+          "CostAmountOperator": 0,
+          "Level": 1,
+          "Learned": 0,
+          "Rating": 8
+        },
+        {
+          "Name": "recall",
+          "ResourceKind": null,
+          "CostAmount": 0,
+          "CostAmountOperator": 0,
+          "Level": 1,
+          "Learned": 40,
+          "Rating": 2
+        },
+        {
+          "Name": "second attack",
+          "ResourceKind": null,
+          "CostAmount": 0,
+          "CostAmountOperator": 0,
+          "Level": 5,
+          "Learned": 0,
+          "Rating": 3
+        },
+        {
+          "Name": "shield block",
+          "ResourceKind": null,
+          "CostAmount": 0,
+          "CostAmountOperator": 0,
+          "Level": 1,
+          "Learned": 0,
+          "Rating": 2
+        },
+        {
+          "Name": "bash",
+          "ResourceKind": null,
+          "CostAmount": 0,
+          "CostAmountOperator": 0,
+          "Level": 1,
+          "Learned": 100,
+          "Rating": 1
+        },
+        {
+          "Name": "disarm",
+          "ResourceKind": null,
+          "CostAmount": 0,
+          "CostAmountOperator": 0,
+          "Level": 11,
+          "Learned": 0,
+          "Rating": 4
+        },
+        {
+          "Name": "enhanced damage",
+          "ResourceKind": null,
+          "CostAmount": 0,
+          "CostAmountOperator": 0,
+          "Level": 1,
+          "Learned": 0,
+          "Rating": 3
+        },
+        {
+          "Name": "parry",
+          "ResourceKind": null,
+          "CostAmount": 0,
+          "CostAmountOperator": 0,
+          "Level": 1,
+          "Learned": 0,
+          "Rating": 4
+        },
+        {
+          "Name": "rescue",
+          "ResourceKind": null,
+          "CostAmount": 0,
+          "CostAmountOperator": 0,
+          "Level": 1,
+          "Learned": 0,
+          "Rating": 4
+        },
+        {
+          "Name": "third attack",
+          "ResourceKind": null,
+          "CostAmount": 0,
+          "CostAmountOperator": 0,
+          "Level": 12,
+          "Learned": 0,
+          "Rating": 4
+        },
+        {
+          "Name": "axe",
+          "ResourceKind": null,
+          "CostAmount": 0,
+          "CostAmountOperator": 0,
+          "Level": 1,
+          "Learned": 0,
+          "Rating": 4
+        },
+        {
+          "Name": "dagger",
+          "ResourceKind": null,
+          "CostAmount": 0,
+          "CostAmountOperator": 0,
+          "Level": 1,
+          "Learned": 0,
+          "Rating": 2
+        },
+        {
+          "Name": "flail",
+          "ResourceKind": null,
+          "CostAmount": 0,
+          "CostAmountOperator": 0,
+          "Level": 1,
+          "Learned": 0,
+          "Rating": 4
+        },
+        {
+          "Name": "mace",
+          "ResourceKind": null,
+          "CostAmount": 0,
+          "CostAmountOperator": 0,
+          "Level": 1,
+          "Learned": 0,
+          "Rating": 3
+        },
+        {
+          "Name": "polearm",
+          "ResourceKind": null,
+          "CostAmount": 0,
+          "CostAmountOperator": 0,
+          "Level": 1,
+          "Learned": 0,
+          "Rating": 4
+        },
+        {
+          "Name": "spear",
+          "ResourceKind": null,
+          "CostAmount": 0,
+          "CostAmountOperator": 0,
+          "Level": 1,
+          "Learned": 0,
+          "Rating": 3
+        },
+        {
+          "Name": "whip",
+          "ResourceKind": null,
+          "CostAmount": 0,
+          "CostAmountOperator": 0,
+          "Level": 1,
+          "Learned": 0,
+          "Rating": 4
+        },
+        {
+          "Name": "Fast healing",
+          "ResourceKind": null,
+          "CostAmount": 0,
+          "CostAmountOperator": 0,
+          "Level": 1,
+          "Learned": 100,
+          "Rating": 1
+        }
+      ],
+      "LearnedAbilityGroups": [
+        {
+          "Name": "rom basics",
+          "Cost": 0
+        },
+        {
+          "Name": "warrior basics",
+          "Cost": 0
+        },
+        {
+          "Name": "warrior default",
+          "Cost": 40
+        }
+      ],
+      "Conditions": {
+        "Drunk": 0,
+        "Full": 8,
+        "Thirst": 38,
+        "Hunger": 28
+      },
+      "Aliases": {},
+      "Cooldowns": {},
+      "Pets": [],
+      "Name": "fnar",
+      "Race": "giant",
+      "Class": "warrior",
+      "Level": 2,
+      "Sex": 1,
+      "Size": 3,
+      "HitPoints": 109,
+      "MovePoints": 109,
+      "CurrentResources": {
+        "Mana": 102,
+        "Psy": 100
+      },
+      "MaxResources": {
+        "Mana": 102,
+        "Psy": 100
+      },
+      "Equipments": [
+        {
+          "Slot": 1,
+          "Item": {
+            "$type": "light",
+            "TimeLeft": 11990,
+            "ItemId": 3716,
+            "Level": 0,
+            "DecayPulseLeft": 0,
+            "ItemFlags": "Glowing,Magic",
+            "Auras": []
+          }
+        },
+        {
+          "Slot": 2,
+          "Item": {
+            "$type": "base",
+            "ItemId": 3706,
+            "Level": 0,
+            "DecayPulseLeft": 0,
+            "ItemFlags": "MeltOnDrop",
+            "Auras": []
+          }
+        },
+        {
+          "Slot": 3,
+          "Item": {
+            "$type": "base",
+            "ItemId": 3705,
+            "Level": 0,
+            "DecayPulseLeft": 0,
+            "ItemFlags": "MeltOnDrop",
+            "Auras": []
+          }
+        },
+        {
+          "Slot": 3,
+          "Item": {
+            "$type": "base",
+            "ItemId": 3705,
+            "Level": 0,
+            "DecayPulseLeft": 0,
+            "ItemFlags": "MeltOnDrop",
+            "Auras": []
+          }
+        },
+        {
+          "Slot": 4,
+          "Item": {
+            "$type": "base",
+            "ItemId": 3703,
+            "Level": 0,
+            "DecayPulseLeft": 0,
+            "ItemFlags": "MeltOnDrop",
+            "Auras": []
+          }
+        },
+        {
+          "Slot": 5,
+          "Item": {
+            "$type": "base",
+            "ItemId": 3711,
+            "Level": 0,
+            "DecayPulseLeft": 0,
+            "ItemFlags": "MeltOnDrop",
+            "Auras": []
+          }
+        },
+        {
+          "Slot": 6,
+          "Item": {
+            "$type": "base",
+            "ItemId": 3712,
+            "Level": 0,
+            "DecayPulseLeft": 0,
+            "ItemFlags": "MeltOnDrop",
+            "Auras": []
+          }
+        },
+        {
+          "Slot": 7,
+          "Item": {
+            "$type": "base",
+            "ItemId": 3713,
+            "Level": 0,
+            "DecayPulseLeft": 0,
+            "ItemFlags": "MeltOnDrop",
+            "Auras": []
+          }
+        },
+        {
+          "Slot": 7,
+          "Item": {
+            "$type": "base",
+            "ItemId": 3713,
+            "Level": 0,
+            "DecayPulseLeft": 0,
+            "ItemFlags": "MeltOnDrop",
+            "Auras": []
+          }
+        },
+        {
+          "Slot": 8,
+          "Item": {
+            "$type": "base",
+            "ItemId": 3710,
+            "Level": 0,
+            "DecayPulseLeft": 0,
+            "ItemFlags": "MeltOnDrop",
+            "Auras": []
+          }
+        },
+        {
+          "Slot": 9,
+          "Item": {
+            "$type": "base",
+            "ItemId": 3709,
+            "Level": 0,
+            "DecayPulseLeft": 0,
+            "ItemFlags": "MeltOnDrop",
+            "Auras": []
+          }
+        },
+        {
+          "Slot": 11,
+          "Item": {
+            "$type": "base",
+            "ItemId": 3707,
+            "Level": 0,
+            "DecayPulseLeft": 0,
+            "ItemFlags": "MeltOnDrop",
+            "Auras": []
+          }
+        },
+        {
+          "Slot": 12,
+          "Item": {
+            "$type": "base",
+            "ItemId": 3708,
+            "Level": 0,
+            "DecayPulseLeft": 0,
+            "ItemFlags": "MeltOnDrop",
+            "Auras": []
+          }
+        },
+        {
+          "Slot": 13,
+          "Item": {
+            "$type": "weapon",
+            "WeaponFlags": "",
+            "ItemId": 3702,
+            "Level": 1,
+            "DecayPulseLeft": 0,
+            "ItemFlags": "MeltOnDrop",
+            "Auras": []
+          }
+        },
+        {
+          "Slot": 14,
+          "Item": {
+            "$type": "base",
+            "ItemId": 3704,
+            "Level": 0,
+            "DecayPulseLeft": 0,
+            "ItemFlags": "MeltOnDrop",
+            "Auras": []
+          }
+        }
+      ],
+      "Inventory": [
+        {
+          "$type": "base",
+          "ItemId": 3715,
+          "Level": 0,
+          "DecayPulseLeft": 0,
+          "ItemFlags": "Magic,MeltOnDrop",
+          "Auras": []
+        },
+        {
+          "$type": "base",
+          "ItemId": 3712,
+          "Level": 0,
+          "DecayPulseLeft": 0,
+          "ItemFlags": "MeltOnDrop",
+          "Auras": []
+        },
+        {
+          "$type": "base",
+          "ItemId": 3707,
+          "Level": 0,
+          "DecayPulseLeft": 0,
+          "ItemFlags": "MeltOnDrop",
+          "Auras": []
+        },
+        {
+          "$type": "base",
+          "ItemId": 3714,
+          "Level": 0,
+          "DecayPulseLeft": 720,
+          "ItemFlags": "",
+          "Auras": []
+        }
+      ],
+      "Auras": [],
+      "CharacterFlags": "",
+      "Immunities": "",
+      "Resistances": "Fire,Cold",
+      "Vulnerabilities": "Mental,Lightning",
+      "ShieldFlags": "",
+      "Attributes": {
+        "Strength": 19,
+        "Intelligence": 11,
+        "Wisdom": 16,
+        "Dexterity": 11,
+        "Constitution": 14,
+        "MaxHitPoints": 109,
+        "SavingThrow": 0,
+        "HitRoll": 0,
+        "DamRoll": 0,
+        "MaxMovePoints": 109,
+        "ArmorBash": 0,
+        "ArmorPierce": 0,
+        "ArmorSlash": 0,
+        "ArmorExotic": 0
+      }
+    },
+    {
+      "CreationTime": "2025-12-08T12:40:06.9440394+01:00",
       "RoomId": 3700,
       "SilverCoins": 0,
       "GoldCoins": 0,
@@ -3482,13 +3951,576 @@
       "CurrentQuests": [],
       "LearnedAbilities": [
         {
-          "Name": "mace",
+          "Name": "dagger",
           "ResourceKind": null,
           "CostAmount": 0,
           "CostAmountOperator": 0,
           "Level": 1,
-          "Learned": 50,
+          "Learned": 40,
           "Rating": 2
+        },
+        {
+          "Name": "scrolls",
+          "ResourceKind": null,
+          "CostAmount": 0,
+          "CostAmountOperator": 0,
+          "Level": 1,
+          "Learned": 0,
+          "Rating": 2
+        },
+        {
+          "Name": "staves",
+          "ResourceKind": null,
+          "CostAmount": 0,
+          "CostAmountOperator": 0,
+          "Level": 1,
+          "Learned": 0,
+          "Rating": 2
+        },
+        {
+          "Name": "wands",
+          "ResourceKind": null,
+          "CostAmount": 0,
+          "CostAmountOperator": 0,
+          "Level": 1,
+          "Learned": 0,
+          "Rating": 2
+        },
+        {
+          "Name": "recall",
+          "ResourceKind": null,
+          "CostAmount": 0,
+          "CostAmountOperator": 0,
+          "Level": 1,
+          "Learned": 40,
+          "Rating": 2
+        },
+        {
+          "Name": "lore",
+          "ResourceKind": null,
+          "CostAmount": 0,
+          "CostAmountOperator": 0,
+          "Level": 10,
+          "Learned": 0,
+          "Rating": 6
+        },
+        {
+          "Name": "calm",
+          "ResourceKind": 0,
+          "CostAmount": 30,
+          "CostAmountOperator": 1,
+          "Level": 48,
+          "Learned": 0,
+          "Rating": 1
+        },
+        {
+          "Name": "charm person",
+          "ResourceKind": 0,
+          "CostAmount": 5,
+          "CostAmountOperator": 1,
+          "Level": 20,
+          "Learned": 0,
+          "Rating": 1
+        },
+        {
+          "Name": "sleep",
+          "ResourceKind": 0,
+          "CostAmount": 15,
+          "CostAmountOperator": 1,
+          "Level": 10,
+          "Learned": 0,
+          "Rating": 1
+        },
+        {
+          "Name": "acid blast",
+          "ResourceKind": 0,
+          "CostAmount": 20,
+          "CostAmountOperator": 1,
+          "Level": 28,
+          "Learned": 0,
+          "Rating": 1
+        },
+        {
+          "Name": "burning hands",
+          "ResourceKind": 0,
+          "CostAmount": 15,
+          "CostAmountOperator": 1,
+          "Level": 7,
+          "Learned": 0,
+          "Rating": 1
+        },
+        {
+          "Name": "chain lightning",
+          "ResourceKind": 0,
+          "CostAmount": 25,
+          "CostAmountOperator": 1,
+          "Level": 33,
+          "Learned": 0,
+          "Rating": 1
+        },
+        {
+          "Name": "chill touch",
+          "ResourceKind": 0,
+          "CostAmount": 15,
+          "CostAmountOperator": 1,
+          "Level": 4,
+          "Learned": 0,
+          "Rating": 1
+        },
+        {
+          "Name": "colour spray",
+          "ResourceKind": 0,
+          "CostAmount": 15,
+          "CostAmountOperator": 1,
+          "Level": 16,
+          "Learned": 0,
+          "Rating": 1
+        },
+        {
+          "Name": "fireball",
+          "ResourceKind": 0,
+          "CostAmount": 15,
+          "CostAmountOperator": 1,
+          "Level": 22,
+          "Learned": 0,
+          "Rating": 1
+        },
+        {
+          "Name": "lightning bolt",
+          "ResourceKind": 0,
+          "CostAmount": 15,
+          "CostAmountOperator": 1,
+          "Level": 13,
+          "Learned": 0,
+          "Rating": 1
+        },
+        {
+          "Name": "magic missile",
+          "ResourceKind": 0,
+          "CostAmount": 15,
+          "CostAmountOperator": 1,
+          "Level": 1,
+          "Learned": 0,
+          "Rating": 1
+        },
+        {
+          "Name": "shocking grasp",
+          "ResourceKind": 0,
+          "CostAmount": 15,
+          "CostAmountOperator": 1,
+          "Level": 10,
+          "Learned": 0,
+          "Rating": 1
+        },
+        {
+          "Name": "detect evil",
+          "ResourceKind": 0,
+          "CostAmount": 5,
+          "CostAmountOperator": 1,
+          "Level": 11,
+          "Learned": 0,
+          "Rating": 1
+        },
+        {
+          "Name": "detect good",
+          "ResourceKind": 0,
+          "CostAmount": 5,
+          "CostAmountOperator": 1,
+          "Level": 11,
+          "Learned": 0,
+          "Rating": 1
+        },
+        {
+          "Name": "detect hidden",
+          "ResourceKind": 0,
+          "CostAmount": 5,
+          "CostAmountOperator": 1,
+          "Level": 15,
+          "Learned": 0,
+          "Rating": 1
+        },
+        {
+          "Name": "detect invis",
+          "ResourceKind": 0,
+          "CostAmount": 5,
+          "CostAmountOperator": 1,
+          "Level": 3,
+          "Learned": 0,
+          "Rating": 1
+        },
+        {
+          "Name": "detect magic",
+          "ResourceKind": 0,
+          "CostAmount": 5,
+          "CostAmountOperator": 1,
+          "Level": 2,
+          "Learned": 0,
+          "Rating": 1
+        },
+        {
+          "Name": "detect poison",
+          "ResourceKind": 0,
+          "CostAmount": 5,
+          "CostAmountOperator": 1,
+          "Level": 15,
+          "Learned": 0,
+          "Rating": 1
+        },
+        {
+          "Name": "farsight",
+          "ResourceKind": 0,
+          "CostAmount": 36,
+          "CostAmountOperator": 1,
+          "Level": 14,
+          "Learned": 0,
+          "Rating": 1
+        },
+        {
+          "Name": "identify",
+          "ResourceKind": 0,
+          "CostAmount": 12,
+          "CostAmountOperator": 1,
+          "Level": 15,
+          "Learned": 0,
+          "Rating": 1
+        },
+        {
+          "Name": "know alignment",
+          "ResourceKind": 0,
+          "CostAmount": 9,
+          "CostAmountOperator": 1,
+          "Level": 12,
+          "Learned": 0,
+          "Rating": 1
+        },
+        {
+          "Name": "locate object",
+          "ResourceKind": 0,
+          "CostAmount": 20,
+          "CostAmountOperator": 1,
+          "Level": 9,
+          "Learned": 0,
+          "Rating": 1
+        },
+        {
+          "Name": "giant strength",
+          "ResourceKind": 0,
+          "CostAmount": 20,
+          "CostAmountOperator": 1,
+          "Level": 11,
+          "Learned": 0,
+          "Rating": 1
+        },
+        {
+          "Name": "haste",
+          "ResourceKind": 0,
+          "CostAmount": 30,
+          "CostAmountOperator": 1,
+          "Level": 21,
+          "Learned": 0,
+          "Rating": 1
+        },
+        {
+          "Name": "infravision",
+          "ResourceKind": 0,
+          "CostAmount": 5,
+          "CostAmountOperator": 1,
+          "Level": 9,
+          "Learned": 0,
+          "Rating": 1
+        },
+        {
+          "Name": "refresh",
+          "ResourceKind": 0,
+          "CostAmount": 12,
+          "CostAmountOperator": 1,
+          "Level": 8,
+          "Learned": 0,
+          "Rating": 1
+        },
+        {
+          "Name": "mass invis",
+          "ResourceKind": 0,
+          "CostAmount": 20,
+          "CostAmountOperator": 1,
+          "Level": 22,
+          "Learned": 0,
+          "Rating": 1
+        },
+        {
+          "Name": "ventriloquate",
+          "ResourceKind": 0,
+          "CostAmount": 5,
+          "CostAmountOperator": 1,
+          "Level": 1,
+          "Learned": 0,
+          "Rating": 1
+        },
+        {
+          "Name": "blindness",
+          "ResourceKind": 0,
+          "CostAmount": 5,
+          "CostAmountOperator": 1,
+          "Level": 12,
+          "Learned": 0,
+          "Rating": 1
+        },
+        {
+          "Name": "curse",
+          "ResourceKind": 0,
+          "CostAmount": 20,
+          "CostAmountOperator": 1,
+          "Level": 18,
+          "Learned": 0,
+          "Rating": 1
+        },
+        {
+          "Name": "energy drain",
+          "ResourceKind": 0,
+          "CostAmount": 35,
+          "CostAmountOperator": 1,
+          "Level": 19,
+          "Learned": 0,
+          "Rating": 1
+        },
+        {
+          "Name": "plague",
+          "ResourceKind": 0,
+          "CostAmount": 20,
+          "CostAmountOperator": 1,
+          "Level": 23,
+          "Learned": 0,
+          "Rating": 1
+        },
+        {
+          "Name": "poison",
+          "ResourceKind": 0,
+          "CostAmount": 10,
+          "CostAmountOperator": 1,
+          "Level": 17,
+          "Learned": 0,
+          "Rating": 1
+        },
+        {
+          "Name": "slow",
+          "ResourceKind": 0,
+          "CostAmount": 30,
+          "CostAmountOperator": 1,
+          "Level": 23,
+          "Learned": 0,
+          "Rating": 1
+        },
+        {
+          "Name": "weaken",
+          "ResourceKind": 0,
+          "CostAmount": 20,
+          "CostAmountOperator": 1,
+          "Level": 11,
+          "Learned": 0,
+          "Rating": 1
+        },
+        {
+          "Name": "armor",
+          "ResourceKind": 0,
+          "CostAmount": 5,
+          "CostAmountOperator": 1,
+          "Level": 7,
+          "Learned": 0,
+          "Rating": 1
+        },
+        {
+          "Name": "cancellation",
+          "ResourceKind": 0,
+          "CostAmount": 20,
+          "CostAmountOperator": 1,
+          "Level": 18,
+          "Learned": 0,
+          "Rating": 1
+        },
+        {
+          "Name": "dispel magic",
+          "ResourceKind": 0,
+          "CostAmount": 15,
+          "CostAmountOperator": 1,
+          "Level": 16,
+          "Learned": 0,
+          "Rating": 1
+        },
+        {
+          "Name": "fireproof",
+          "ResourceKind": 0,
+          "CostAmount": 10,
+          "CostAmountOperator": 1,
+          "Level": 13,
+          "Learned": 0,
+          "Rating": 1
+        },
+        {
+          "Name": "protection evil",
+          "ResourceKind": 0,
+          "CostAmount": 5,
+          "CostAmountOperator": 1,
+          "Level": 12,
+          "Learned": 0,
+          "Rating": 1
+        },
+        {
+          "Name": "protection good",
+          "ResourceKind": 0,
+          "CostAmount": 5,
+          "CostAmountOperator": 1,
+          "Level": 12,
+          "Learned": 0,
+          "Rating": 1
+        },
+        {
+          "Name": "sanctuary",
+          "ResourceKind": 0,
+          "CostAmount": 75,
+          "CostAmountOperator": 1,
+          "Level": 36,
+          "Learned": 0,
+          "Rating": 1
+        },
+        {
+          "Name": "shield",
+          "ResourceKind": 0,
+          "CostAmount": 12,
+          "CostAmountOperator": 1,
+          "Level": 20,
+          "Learned": 0,
+          "Rating": 1
+        },
+        {
+          "Name": "stone skin",
+          "ResourceKind": 0,
+          "CostAmount": 12,
+          "CostAmountOperator": 1,
+          "Level": 25,
+          "Learned": 0,
+          "Rating": 1
+        },
+        {
+          "Name": "fly",
+          "ResourceKind": 0,
+          "CostAmount": 10,
+          "CostAmountOperator": 1,
+          "Level": 10,
+          "Learned": 0,
+          "Rating": 1
+        },
+        {
+          "Name": "gate",
+          "ResourceKind": 0,
+          "CostAmount": 80,
+          "CostAmountOperator": 1,
+          "Level": 27,
+          "Learned": 0,
+          "Rating": 1
+        },
+        {
+          "Name": "nexus",
+          "ResourceKind": 0,
+          "CostAmount": 150,
+          "CostAmountOperator": 1,
+          "Level": 40,
+          "Learned": 0,
+          "Rating": 2
+        },
+        {
+          "Name": "pass door",
+          "ResourceKind": 0,
+          "CostAmount": 20,
+          "CostAmountOperator": 1,
+          "Level": 24,
+          "Learned": 0,
+          "Rating": 1
+        },
+        {
+          "Name": "portal",
+          "ResourceKind": 0,
+          "CostAmount": 100,
+          "CostAmountOperator": 1,
+          "Level": 35,
+          "Learned": 0,
+          "Rating": 2
+        },
+        {
+          "Name": "summon",
+          "ResourceKind": 0,
+          "CostAmount": 50,
+          "CostAmountOperator": 1,
+          "Level": 24,
+          "Learned": 0,
+          "Rating": 1
+        },
+        {
+          "Name": "teleport",
+          "ResourceKind": 0,
+          "CostAmount": 35,
+          "CostAmountOperator": 1,
+          "Level": 13,
+          "Learned": 0,
+          "Rating": 1
+        },
+        {
+          "Name": "word of recall",
+          "ResourceKind": 0,
+          "CostAmount": 5,
+          "CostAmountOperator": 1,
+          "Level": 32,
+          "Learned": 0,
+          "Rating": 1
+        },
+        {
+          "Name": "call lightning",
+          "ResourceKind": 0,
+          "CostAmount": 15,
+          "CostAmountOperator": 1,
+          "Level": 26,
+          "Learned": 0,
+          "Rating": 1
+        },
+        {
+          "Name": "control weather",
+          "ResourceKind": 0,
+          "CostAmount": 25,
+          "CostAmountOperator": 1,
+          "Level": 15,
+          "Learned": 0,
+          "Rating": 1
+        },
+        {
+          "Name": "faerie fire",
+          "ResourceKind": 0,
+          "CostAmount": 5,
+          "CostAmountOperator": 1,
+          "Level": 6,
+          "Learned": 0,
+          "Rating": 1
+        },
+        {
+          "Name": "faerie fog",
+          "ResourceKind": 0,
+          "CostAmount": 12,
+          "CostAmountOperator": 1,
+          "Level": 14,
+          "Learned": 0,
+          "Rating": 1
+        }
+      ],
+      "LearnedAbilityGroups": [
+        {
+          "Name": "rom basics",
+          "Cost": 0
+        },
+        {
+          "Name": "mage basics",
+          "Cost": 0
+        },
+        {
+          "Name": "mage default",
+          "Cost": 40
         }
       ],
       "Conditions": {
@@ -3499,12 +4531,12 @@
       "Aliases": {},
       "Cooldowns": {},
       "Pets": [],
-      "Name": "toto",
-      "Race": "dwarf",
-      "Class": "cleric",
+      "Name": "alhazred",
+      "Race": "elf",
+      "Class": "mage",
       "Level": 1,
       "Sex": 1,
-      "Size": 1,
+      "Size": 2,
       "HitPoints": 100,
       "MovePoints": 100,
       "CurrentResources": {
@@ -3518,17 +4550,17 @@
       "Equipments": [],
       "Inventory": [],
       "Auras": [],
-      "CharacterFlags": "Infrared",
+      "CharacterFlags": "",
       "Immunities": "",
-      "Resistances": "Poison,Disease",
-      "Vulnerabilities": "Drowning",
+      "Resistances": "Charm",
+      "Vulnerabilities": "Iron",
       "ShieldFlags": "",
       "Attributes": {
-        "Strength": 14,
-        "Intelligence": 12,
-        "Wisdom": 17,
-        "Dexterity": 10,
-        "Constitution": 15,
+        "Strength": 12,
+        "Intelligence": 17,
+        "Wisdom": 13,
+        "Dexterity": 15,
+        "Constitution": 11,
         "MaxHitPoints": 100,
         "SavingThrow": 0,
         "HitRoll": 0,

--- a/Mud.Common/StringCompareHelpers.cs
+++ b/Mud.Common/StringCompareHelpers.cs
@@ -8,16 +8,16 @@ public static class StringCompareHelpers
     public static readonly Func<string, string, bool> StringStartsWith = (s, s1)
         => s.StartsWith(s1, StringComparison.InvariantCultureIgnoreCase);
 
-    public static readonly Func<IEnumerable<string>, string, bool> StringListEquals = (enumerable, s)
+    public static readonly Func<IEnumerable<string>, string, bool> AnyStringEquals = (enumerable, s)
         => enumerable.Any(x => StringEquals(x, s));
 
-    public static readonly Func<IEnumerable<string>, string, bool> StringListStartsWith = (enumerable, s)
+    public static readonly Func<IEnumerable<string>, string, bool> AnyStringStartsWith = (enumerable, s)
         => enumerable.Any(x => StringStartsWith(x, s));
 
     // every item in enumerable1 must be found in enumerable
-    public static readonly Func<IEnumerable<string>, IEnumerable<string>, bool> StringListsEquals = (enumerable, enumerable1)
+    public static readonly Func<IEnumerable<string>, IEnumerable<string>, bool> AllStringsEquals = (enumerable, enumerable1)
         => enumerable1.All(x => enumerable.Any(y => StringEquals(y, x)));
 
-    public static readonly Func<IEnumerable<string>, IEnumerable<string>, bool> StringListsStartsWith = (enumerable, enumerable1)
+    public static readonly Func<IEnumerable<string>, IEnumerable<string>, bool> AllStringsStartsWith = (enumerable, enumerable1)
         => enumerable1.All(x => enumerable.Any(y => StringStartsWith(y, x)));
 }

--- a/Mud.Domain/SerializationData/LearnedAbilityGroupData.cs
+++ b/Mud.Domain/SerializationData/LearnedAbilityGroupData.cs
@@ -1,0 +1,8 @@
+﻿namespace Mud.Domain.SerializationData;
+
+public class LearnedAbilityGroupData
+{
+    public required string Name { get; set; }
+
+    public required int Cost { get; set; }
+}

--- a/Mud.Domain/SerializationData/PlayableCharacterData.cs
+++ b/Mud.Domain/SerializationData/PlayableCharacterData.cs
@@ -23,6 +23,7 @@ public class PlayableCharacterData : CharacterData
     public required CurrentQuestData[] CurrentQuests { get; set; }
 
     public required LearnedAbilityData[] LearnedAbilities { get; set; }
+    public /*required*/ LearnedAbilityGroupData[] LearnedAbilityGroups { get; set; } = [];
 
     public required Dictionary<Conditions, int> Conditions { get; set; }
 

--- a/Mud.Importer.Rom/RomImporter.cs
+++ b/Mud.Importer.Rom/RomImporter.cs
@@ -250,6 +250,8 @@ public class RomImporter
         // EX_INFURIATING
         // EX_NOCLOSE
         // EX_NOLOCK
+        if (flags != 0)
+            flags |= ExitFlags.Door; // force door if another flag found
         return flags;
     }
 

--- a/Mud.Repository.Tests/JsonSerializerTests.cs
+++ b/Mud.Repository.Tests/JsonSerializerTests.cs
@@ -47,6 +47,7 @@ namespace Mud.Repository.Tests
                 AutoFlags = AutoFlags.None,
                 CurrentQuests = [],
                 LearnedAbilities = [],
+                LearnedAbilityGroups = [],
                 Conditions = [],
                 Aliases = [],
                 Cooldowns = [],

--- a/Mud.Server.Ability/AbilityAttribute.cs
+++ b/Mud.Server.Ability/AbilityAttribute.cs
@@ -64,7 +64,7 @@ public class PassiveAttribute : AbilityBaseAttribute
 
 public class WeaponAttribute : AbilityBaseAttribute
 {
-    public override AbilityTypes Type => AbilityTypes.Passive;
+    public override AbilityTypes Type => AbilityTypes.Weapon;
 
     public string[] WeaponTypes { get; set; }
 

--- a/Mud.Server.Ability/AbilityGroup/AbilityGroupBase.cs
+++ b/Mud.Server.Ability/AbilityGroup/AbilityGroupBase.cs
@@ -1,0 +1,29 @@
+﻿using Mud.Server.Interfaces.AbilityGroup;
+
+namespace Mud.Server.Ability.AbilityGroup
+{
+    public abstract class AbilityGroupBase : IAbilityGroup
+    {
+        private readonly List<string> _abilityGroups = [];
+        private readonly List<string> _abilities = [];
+
+        #region IAbilityGroup
+
+        public abstract string Name { get; }
+
+        public IEnumerable<string> AbilityGroups => _abilityGroups;
+        public IEnumerable<string> Abilities => _abilities;
+
+        #endregion
+
+        public void AddAbilityGroup(string name)
+        {
+            _abilityGroups.Add(name);
+        }
+
+        public void AddAbility(string name)
+        {
+            _abilities.Add(name);
+        }
+    }
+}

--- a/Mud.Server.Ability/AbilityGroup/AbilityGroupInfo.cs
+++ b/Mud.Server.Ability/AbilityGroup/AbilityGroupInfo.cs
@@ -1,0 +1,20 @@
+﻿using Mud.Server.Interfaces.Ability;
+using Mud.Server.Interfaces.AbilityGroup;
+
+namespace Mud.Server.Ability.AbilityGroup
+{
+    public class AbilityGroupInfo : IAbilityGroupInfo
+    {
+        public string Name { get; }
+
+        public IEnumerable<IAbilityGroupInfo> AbilityGroupInfos { get; }
+        public IEnumerable<IAbilityInfo> AbilityInfos { get; }
+
+        public AbilityGroupInfo(string name, IEnumerable<IAbilityGroupInfo> abilityGroupInfos, IEnumerable<IAbilityInfo> abilityInfos)
+        {
+            Name = name;
+            AbilityGroupInfos = abilityGroupInfos;
+            AbilityInfos = abilityInfos;
+        }
+    }
+}

--- a/Mud.Server.Ability/AbilityGroup/AbilityGroupLearned.cs
+++ b/Mud.Server.Ability/AbilityGroup/AbilityGroupLearned.cs
@@ -1,0 +1,37 @@
+﻿using Mud.Domain.SerializationData;
+using Mud.Server.Interfaces.AbilityGroup;
+
+namespace Mud.Server.Ability.AbilityGroup
+{
+    public class AbilityGroupLearned : IAbilityGroupLearned
+    {
+        public string Name { get; }
+
+        public int Cost { get; }
+
+        public IAbilityGroupInfo AbilityGroupInfo { get; }
+
+        public AbilityGroupLearned(IAbilityGroupUsage abilityGroupUsage)
+        {
+            Name = abilityGroupUsage.Name;
+            Cost = abilityGroupUsage.Cost;
+            AbilityGroupInfo = abilityGroupUsage.AbilityGroupInfo;
+        }
+
+        public AbilityGroupLearned(LearnedAbilityGroupData learnedAbilityGroupData, IAbilityGroupInfo abilityGroupInfo)
+        {
+            Name = learnedAbilityGroupData.Name;
+            Cost = learnedAbilityGroupData.Cost;
+            AbilityGroupInfo = abilityGroupInfo;
+        }
+
+        public LearnedAbilityGroupData MapLearnedAbilityGroupData()
+        {
+            return new LearnedAbilityGroupData
+            {
+                Name = Name,
+                Cost = Cost
+            };
+        }
+    }
+}

--- a/Mud.Server.Ability/AbilityGroup/AbilityGroupManager.cs
+++ b/Mud.Server.Ability/AbilityGroup/AbilityGroupManager.cs
@@ -1,0 +1,87 @@
+﻿using Microsoft.Extensions.Logging;
+using Mud.Common;
+using Mud.Common.Attributes;
+using Mud.Server.Interfaces.Ability;
+using Mud.Server.Interfaces.AbilityGroup;
+
+namespace Mud.Server.Ability.AbilityGroup
+{
+    [Export(typeof(IAbilityGroupManager)), Shared]
+    public class AbilityGroupManager : IAbilityGroupManager
+    {
+        private ILogger<AbilityGroupManager> Logger { get; }
+        private IAbilityManager AbilityManager { get; }
+
+        private readonly Dictionary<string, IAbilityGroupInfo> _abilityGroupByName;
+
+        public AbilityGroupManager(ILogger<AbilityGroupManager> logger, IAbilityManager abilityManager, IEnumerable<IAbilityGroup> abilityGroups)
+        {
+            Logger = logger;
+            AbilityManager = abilityManager;
+
+            _abilityGroupByName = new Dictionary<string, IAbilityGroupInfo>(StringComparer.InvariantCultureIgnoreCase);
+            GenerateAbilityGroupInfos(abilityGroups);
+        }
+
+        public IAbilityGroupInfo? this[string abilityGroupName]
+        {
+            get
+            {
+                if (!_abilityGroupByName.TryGetValue(abilityGroupName, out var abilityGroupInfo))
+                    return null;
+                return abilityGroupInfo;
+            }
+        }
+
+        private void GenerateAbilityGroupInfos(IEnumerable<IAbilityGroup> abilityGroups)
+        {
+            foreach (var abilityGroup in abilityGroups)
+            {
+                if (!_abilityGroupByName.ContainsKey(abilityGroup.Name))
+                {
+                    GenerateAbilityGroupInfo(abilityGroup.Name, abilityGroup.AbilityGroups, abilityGroup.Abilities, abilityGroups);
+                }
+            }
+        }
+
+        private IAbilityGroupInfo GenerateAbilityGroupInfo(string groupName, IEnumerable<string> subGroupNames, IEnumerable<string> abilityNames, IEnumerable<IAbilityGroup> abilityGroups)
+        {
+            // TODO: handle cycle
+            // TODO: what if a group is defined twice with a different ability composition ?
+            if (_abilityGroupByName.TryGetValue(groupName, out var existingAbilityGroupInfo))
+                return existingAbilityGroupInfo;
+            var subAbilityGroupInfos = new List<IAbilityGroupInfo>();
+            foreach (var subGroupName in subGroupNames)
+            {
+                if (_abilityGroupByName.TryGetValue(subGroupName, out var subAbilityGroupInfo))
+                    subAbilityGroupInfos.Add(subAbilityGroupInfo);
+                else
+                {
+                    var subAbilityGroup = abilityGroups.SingleOrDefault(x => StringCompareHelpers.StringEquals(x.Name, subGroupName));
+                    if (subAbilityGroup == null)
+                        Logger.LogError("Ability group [{subGroupName}] defined in ability group [{groupName}] doesn't exist", subGroupName, groupName);
+                    else
+                    {
+                        subAbilityGroupInfo = GenerateAbilityGroupInfo(subGroupName, subAbilityGroup.AbilityGroups, subAbilityGroup.Abilities, abilityGroups);
+                        subAbilityGroupInfos.Add(subAbilityGroupInfo);
+                    }
+                }
+
+            }
+            var abilityInfos = new List<IAbilityInfo>();
+            foreach (var abilityName in abilityNames)
+            {
+                var abilityInfo = AbilityManager[abilityName];
+                if (abilityInfo == null)
+                    Logger.LogError("Ability [{abilityName}] defined in group [{abilityGroupName}] doesn't exist", abilityName, groupName);
+                else
+                {
+                    abilityInfos.Add(abilityInfo);
+                }
+            }
+            var abilityGroupInfo = new AbilityGroupInfo(groupName, subAbilityGroupInfos, abilityInfos);
+            _abilityGroupByName.Add(groupName, abilityGroupInfo);
+            return abilityGroupInfo;
+        }
+    }
+}

--- a/Mud.Server.Ability/AbilityGroup/AbilityGroupUsage.cs
+++ b/Mud.Server.Ability/AbilityGroup/AbilityGroupUsage.cs
@@ -1,0 +1,20 @@
+﻿using Mud.Server.Interfaces.AbilityGroup;
+
+namespace Mud.Server.Ability.AbilityGroup
+{
+    public class AbilityGroupUsage : IAbilityGroupUsage
+    {
+        public string Name { get; }
+
+        public int Cost { get; }
+
+        public IAbilityGroupInfo AbilityGroupInfo { get; }
+
+        public AbilityGroupUsage(string name, int cost, IAbilityGroupInfo abilityGroupInfo)
+        {
+            Name = name;
+            Cost = cost;
+            AbilityGroupInfo = abilityGroupInfo;
+        }
+    }
+}

--- a/Mud.Server.Ability/AbilityLearned.cs
+++ b/Mud.Server.Ability/AbilityLearned.cs
@@ -25,7 +25,6 @@ public class AbilityLearned : IAbilityLearned
     public int Learned { get; protected set; }
 
     public AbilityLearned(IAbilityUsage abilityUsage)
-        : base()
     {
         Name = abilityUsage.Name;
         Level = abilityUsage.Level;

--- a/Mud.Server.Class/ClassSanityCheck.cs
+++ b/Mud.Server.Class/ClassSanityCheck.cs
@@ -28,7 +28,7 @@ public class ClassSanityCheck : ISanityCheck
                 Logger.LogWarning("Class {name} doesn't have any allowed resources", c.Name);
             else
             {
-                foreach (IAbilityUsage abilityUsage in c.Abilities)
+                foreach (IAbilityUsage abilityUsage in c.AvailableAbilities)
                     if (abilityUsage.ResourceKind.HasValue && !c.ResourceKinds.Contains(abilityUsage.ResourceKind.Value))
                         Logger.LogWarning("Class {name} is allowed to use ability {abilityName} [resource:{resource}] but doesn't have access to that resource", c.DisplayName, abilityUsage.Name, abilityUsage.ResourceKind);
             }

--- a/Mud.Server.Commands/Actor/Help.cs
+++ b/Mud.Server.Commands/Actor/Help.cs
@@ -5,6 +5,7 @@ using Mud.Server.Interfaces.Ability;
 using Mud.Server.Interfaces.Class;
 using Mud.Server.Interfaces.GameAction;
 using Mud.Server.Interfaces.Race;
+using Mud.Server.TableGenerator;
 using System.Text;
 
 namespace Mud.Server.Commands.Actor;
@@ -203,26 +204,33 @@ public class Help : ActorGameAction
 
     private void AppendRaces(StringBuilder sb, Func<string, bool> nameFilterFunc)
     {
-        foreach (var raceInfo in RaceManager.PlayableRaces.Where(x => nameFilterFunc(x.Name)).OrderBy(x => x.Name))
+        foreach (var race in RaceManager.PlayableRaces.Where(x => nameFilterFunc(x.Name)).OrderBy(x => x.Name))
         {
-            sb.AppendLine($"%C%{raceInfo.Name.ToPascalCase()}%x% [Race]");
-            if (raceInfo.Help != null)
+            sb.AppendLine($"%C%{race.Name.ToPascalCase()}%x% [Race]");
+            if (race.Help != null)
             {
-                sb.AppendLine(raceInfo.Help);
+                sb.AppendLine(race.Help);
             }
+
             sb.AppendLine();
         }
     }
 
     private void AppendClasses(StringBuilder sb, Func<string, bool> nameFilterFunc)
     {
-        foreach (var classInfo in ClassManager.Classes.Where(x => nameFilterFunc(x.Name)).OrderBy(x => x.Name))
+        foreach (var @class in ClassManager.Classes.Where(x => nameFilterFunc(x.Name)).OrderBy(x => x.Name))
         {
-            sb.AppendLine($"%C%{classInfo.Name.ToPascalCase()}%x% [Class]");
-            if (classInfo.Help != null)
+            sb.AppendLine($"%C%{@class.Name.ToPascalCase()}%x% [Class]");
+            if (@class.Help != null)
             {
-                sb.AppendLine(classInfo.Help);
+                sb.AppendLine(@class.Help);
             }
+            var basicAbilityGroups = TableGenerators.AbilityGroupTableGenerator.Value.Generate("Basics:", 3, @class.BasicAbilityGroups);
+            sb.Append(basicAbilityGroups);
+            var defaultAbilityGroups = TableGenerators.AbilityGroupTableGenerator.Value.Generate("Default:", 3, @class.DefaultAbilityGroups);
+            sb.Append(defaultAbilityGroups);
+            var availableAbilityGroups = TableGenerators.AbilityGroupTableGenerator.Value.Generate("Available:", 3, @class.AvailableAbilityGroups.OrderByDescending(x => x.Cost).ThenBy(x => x.Name));
+            sb.Append(availableAbilityGroups);
             sb.AppendLine();
         }
     }

--- a/Mud.Server.Commands/Admin/Information/AbilitiesAdminGameActionBase.cs
+++ b/Mud.Server.Commands/Admin/Information/AbilitiesAdminGameActionBase.cs
@@ -54,6 +54,7 @@ public abstract class AbilitiesAdminGameActionBase : AdminGameAction
         {
             title = AbilityTypesFilter.Value switch
             {
+                AbilityTypes.Weapon => "Weapons",
                 AbilityTypes.Passive => "Passives",
                 AbilityTypes.Spell => "Spells",
                 AbilityTypes.Skill => "Skills",
@@ -75,7 +76,7 @@ public abstract class AbilitiesAdminGameActionBase : AdminGameAction
         // filter on class?
         if (Class != null)
         {
-            var sb = TableGenerators.FullInfoAbilityUsageTableGenerator.Value.Generate($"{title} for {Class.DisplayName}", Class.Abilities
+            var sb = TableGenerators.FullInfoAbilityUsageTableGenerator.Value.Generate($"{title} for {Class.DisplayName}", Class.AvailableAbilities
                 .Where(x => !AbilityTypesFilter.HasValue || x.AbilityInfo.Type == AbilityTypesFilter.Value)
                 .OrderBy(x => x.Level)
                 .ThenBy(x => x.Name));

--- a/Mud.Server.Commands/Admin/Information/Info.cs
+++ b/Mud.Server.Commands/Admin/Information/Info.cs
@@ -113,7 +113,7 @@ public class Info : AdminGameAction
                     $"Max practice percentage: %W%{Class.MaxPracticePercentage}%x%",
                     $"Hp/level: min: %W%{Class.MinHitPointGainPerLevel}%x% max: %W%{Class.MaxHitPointGainPerLevel}%x%"
                 ],
-                Class.Abilities.OrderBy(x => x.Level).ThenBy(x => x.Name));
+                Class.AvailableAbilities.OrderBy(x => x.Level).ThenBy(x => x.Name));
             Actor.Page(sb);
             return;
         }

--- a/Mud.Server.Commands/Admin/Information/Weapons.cs
+++ b/Mud.Server.Commands/Admin/Information/Weapons.cs
@@ -1,0 +1,21 @@
+﻿using Mud.Server.GameAction;
+using Mud.Server.Interfaces.Ability;
+using Mud.Server.Interfaces.Class;
+using Mud.Server.Interfaces.Race;
+
+namespace Mud.Server.Commands.Admin.Information;
+
+[AdminCommand("Weapons", "Information")]
+[Syntax(
+    "[cmd]",
+    "[cmd] <class>",
+    "[cmd] <race>")]
+public class Weapons : AbilitiesAdminGameActionBase
+{
+    public Weapons(IAbilityManager abilityManager, IClassManager classManager, IRaceManager raceManager)
+        : base(abilityManager, classManager, raceManager)
+    {
+    }
+
+    protected override AbilityTypes? AbilityTypesFilter => AbilityTypes.Weapon;
+}

--- a/Mud.Server.Commands/Character/Ability/AbilitiesCharacterGameActionBase.cs
+++ b/Mud.Server.Commands/Character/Ability/AbilitiesCharacterGameActionBase.cs
@@ -39,11 +39,11 @@ public abstract class AbilitiesCharacterGameActionBase : CharacterGameAction
     {
         IEnumerable<IAbilityLearned> abilities = Actor.LearnedAbilities
             //.Where(x => (displayAll || x.Level <= Level) && (displayAll || x.Learned > 0) && filterOnAbilityKind(x.Ability.Kind))
-            .Where(x => (DisplayAll || x.Level <= Actor.Level) && x.Learned > 0 && AbilityTypeFilterFunc(x.AbilityInfo.Type))
+            .Where(x => (DisplayAll || (x.Level <= Actor.Level && x.Learned > 0)) && AbilityTypeFilterFunc(x.AbilityInfo.Type))
             .OrderBy(x => x.Level)
             .ThenBy(x => x.Name);
 
-        var sb = TableGenerators.LearnedAbilitiesTableGenerator.Value.Generate("Abilities", abilities);
+        var sb = TableGenerators.LearnedAbilitiesTableGenerator.Value.Generate(Title, abilities);
         Actor.Page(sb);
     }
 }

--- a/Mud.Server.Commands/Character/Ability/Skills.cs
+++ b/Mud.Server.Commands/Character/Ability/Skills.cs
@@ -3,12 +3,14 @@ using Mud.Server.Interfaces.Ability;
 
 namespace Mud.Server.Commands.Character.Ability;
 
-[CharacterCommand("skills", "Ability")]
+[CharacterCommand("skills", "Ability", Priority = 60)]
+[Alias("passives")]
+[Alias("weapons")]
 [Syntax(
     "[cmd]",
     "[cmd] all")]
 public class Skills : AbilitiesCharacterGameActionBase
 {
-    protected override Func<AbilityTypes, bool> AbilityTypeFilterFunc => x => x == AbilityTypes.Skill || x == AbilityTypes.Passive;
-    protected override string Title => "Skills";
+    protected override Func<AbilityTypes, bool> AbilityTypeFilterFunc => x => x == AbilityTypes.Skill || x == AbilityTypes.Passive || x == AbilityTypes.Weapon;
+    protected override string Title => "Skills/Passives/Weapons";
 }

--- a/Mud.Server.Commands/Character/Information/Look.cs
+++ b/Mud.Server.Commands/Character/Information/Look.cs
@@ -262,7 +262,7 @@ public class Look : CharacterGameAction
                     }
             }
             // Search in item keywords
-            if (StringCompareHelpers.StringListsStartsWith(item.Keywords, parameter.Tokens)
+            if (StringCompareHelpers.AllStringsStartsWith(item.Keywords, parameter.Tokens)
                 && ++count == parameter.Count)
             {
                 StringBuilder sb = new();

--- a/Mud.Server.Commands/Character/Information/Where.cs
+++ b/Mud.Server.Commands/Character/Information/Where.cs
@@ -61,7 +61,7 @@ public class Where : CharacterGameAction
                                                                          && !x.CharacterFlags.IsSet("Sneak")
                                                                          && !x.CharacterFlags.IsSet("Hide")
                                                                          && Actor.CanSee(x)
-                                                                         && StringCompareHelpers.StringListsStartsWith(x.Keywords, Pattern.Tokens));
+                                                                         && StringCompareHelpers.AllStringsStartsWith(x.Keywords, Pattern.Tokens));
             notFound = $"You didn't find any {Pattern.Value}.";
         }
         bool found = false;

--- a/Mud.Server.Commands/Character/PlayableCharacter/Ability/Gain.cs
+++ b/Mud.Server.Commands/Character/PlayableCharacter/Ability/Gain.cs
@@ -67,6 +67,9 @@ public class Gain : PlayableCharacterGameAction
         if (actionInput.Parameters.Length == 0)
             return Actor.ActPhrase("{0:N} tells you 'Pardon me?'", Trainer);
 
+        if (actionInput.Parameters[0].IsAll)
+            return "You can't gain that.";
+
         // list
         if (StringCompareHelpers.StringStartsWith("list", actionInput.Parameters[0].Value))
         {
@@ -76,13 +79,13 @@ public class Gain : PlayableCharacterGameAction
         // skills + passives
         if (StringCompareHelpers.StringStartsWith("skills", actionInput.Parameters[0].Value))
         {
-            Action = Actions.DisplaySpells;
+            Action = Actions.DisplaySkillsAndPassives;
             return null;
         }
         // spells
         if (StringCompareHelpers.StringStartsWith("spells", actionInput.Parameters[0].Value))
         {
-            Action = Actions.DisplaySkillsAndPassives;
+            Action = Actions.DisplaySpells;
             return null;
         }
         // convert
@@ -127,7 +130,7 @@ public class Gain : PlayableCharacterGameAction
                 }
             case Actions.DisplaySpells:
                 {
-                    StringBuilder sb = GainAbilityTableGenerator.Value.Generate("Skills and Passives", 3, Actor.LearnedAbilities.Where(x => (x.AbilityInfo.Type == AbilityTypes.Skill || x.AbilityInfo.Type == AbilityTypes.Passive) && x.CanBeGained(Actor)).OrderBy(x => x.Level).ThenBy(x => x.Name));
+                    StringBuilder sb = GainAbilityTableGenerator.Value.Generate("Skills/Passives/Weapons", 3, Actor.LearnedAbilities.Where(x => (x.AbilityInfo.Type == AbilityTypes.Skill || x.AbilityInfo.Type == AbilityTypes.Passive || x.AbilityInfo.Type == AbilityTypes.Weapon) && x.CanBeGained(Actor)).OrderBy(x => x.Level).ThenBy(x => x.Name));
                     Actor.Send(sb);
                     return;
                 }

--- a/Mud.Server.Commands/Character/PlayableCharacter/Ability/Practice.cs
+++ b/Mud.Server.Commands/Character/PlayableCharacter/Ability/Practice.cs
@@ -50,6 +50,8 @@ public class Practice : PlayableCharacterGameAction
             Display = true;
             return null;
         }
+        if (actionInput.Parameters[0].IsAll)
+            return "You can't practice that.";
 
         // practice
         var practicer = Actor.Room?.NonPlayableCharacters.FirstOrDefault(x => Actor.CanSee(x) && x.ActFlags.IsSet("Practice"));

--- a/Mud.Server.Commands/Character/PlayableCharacter/Attribute/Train.cs
+++ b/Mud.Server.Commands/Character/PlayableCharacter/Attribute/Train.cs
@@ -59,6 +59,8 @@ public class Train : PlayableCharacterGameAction
             Action = Actions.Display;
             return null;
         }
+        if (actionInput.Parameters[0].IsAll)
+            return "You can't train that.";
         // basic attribute
         var attributeFound = Enum.GetValues<BasicAttributes>().Select(x => new { attribute = x, name = x.ToString() }).FirstOrDefault(x => StringCompareHelpers.StringStartsWith(x.name, actionInput.Parameters[0].Value));
         if (attributeFound != null)

--- a/Mud.Server.Commands/Character/PlayableCharacter/Information/Auto.cs
+++ b/Mud.Server.Commands/Character/PlayableCharacter/Information/Auto.cs
@@ -12,6 +12,7 @@ namespace Mud.Server.Commands.Character.PlayableCharacter.Information;
 [PlayableCharacterCommand("auto", "Information")]
 [Syntax(
     "[cmd]",
+    "[cmd] all",
     "[cmd] assist",
     "[cmd] exit",
     "[cmd] sacrifice",
@@ -23,6 +24,7 @@ namespace Mud.Server.Commands.Character.PlayableCharacter.Information;
 @"To ease the boredom of always splitting gold and sacrificing corpses.
 The commands are as follows:
 
+all       : active every 'auto'
 assit     : makes you help group members in combat
 exit      : display room exits upon entering a room
 sacrifice : sacrifice dead monsters (if autoloot is on, only empty corpes)

--- a/Mud.Server.Commands/Player/Avatar/CreateAvatar.cs
+++ b/Mud.Server.Commands/Player/Avatar/CreateAvatar.cs
@@ -19,7 +19,6 @@ public class CreateAvatar : PlayerGameAction
     private IServerPlayerCommand ServerPlayerCommand { get; }
     private IRaceManager RaceManager { get; }
     private IClassManager ClassManager { get; }
-    private IAbilityManager AbilityManager { get; }
     private IUniquenessManager UniquenessManager { get; }
     private ITimeManager TimeManager { get; }
     private IRoomManager RoomManager { get; }
@@ -27,13 +26,12 @@ public class CreateAvatar : PlayerGameAction
     private IGameActionManager GameActionManager { get; }
     private int MaxAvatarCount { get; }
 
-    public CreateAvatar(ILogger<CreateAvatar> logger, IServerPlayerCommand serverPlayerCommand, IRaceManager raceManager, IClassManager classManager, IAbilityManager abilityManager, IUniquenessManager uniquenessManager, ITimeManager timeManager, IRoomManager roomManager, IFlagFactory<IShieldFlags, IShieldFlagValues> shieldFlagFactory, IGameActionManager gameActionManager, IOptions<AvatarOptions> avatarOptions)
+    public CreateAvatar(ILogger<CreateAvatar> logger, IServerPlayerCommand serverPlayerCommand, IRaceManager raceManager, IClassManager classManager, IUniquenessManager uniquenessManager, ITimeManager timeManager, IRoomManager roomManager, IFlagFactory<IShieldFlags, IShieldFlagValues> shieldFlagFactory, IGameActionManager gameActionManager, IOptions<AvatarOptions> avatarOptions)
     {
         Logger = logger;
         ServerPlayerCommand = serverPlayerCommand;
         RaceManager = raceManager;
         ClassManager = classManager;
-        AbilityManager = abilityManager;
         UniquenessManager = uniquenessManager;
         TimeManager = timeManager;
         RoomManager = roomManager;
@@ -56,6 +54,6 @@ public class CreateAvatar : PlayerGameAction
     public override void Execute(IActionInput actionInput)
     {
         Actor.Send("Please choose an avatar name (type quit to stop and cancel creation).");
-        Actor.SetStateMachine(new AvatarCreationStateMachine(Logger, ServerPlayerCommand, RaceManager, ClassManager, AbilityManager, UniquenessManager, TimeManager, RoomManager, ShieldFlagFactory, GameActionManager));
+        Actor.SetStateMachine(new AvatarCreationStateMachine(Logger, ServerPlayerCommand, RaceManager, ClassManager, UniquenessManager, TimeManager, RoomManager, ShieldFlagFactory, GameActionManager));
     }
 }

--- a/Mud.Server.Common/Helpers/FindHelpers.cs
+++ b/Mud.Server.Common/Helpers/FindHelpers.cs
@@ -82,24 +82,24 @@ public static class FindHelpers
         where T : IEntity?
     {
         return perfectMatch
-            ? list.Where(x => StringCompareHelpers.StringListsEquals(x!.Keywords, parameter.Tokens)).ElementAtOrDefault(parameter.Count - 1)
-            : list.Where(x => StringCompareHelpers.StringListsStartsWith(x!.Keywords, parameter.Tokens)).ElementAtOrDefault(parameter.Count - 1);
+            ? list.Where(x => StringCompareHelpers.AllStringsEquals(x!.Keywords, parameter.Tokens)).ElementAtOrDefault(parameter.Count - 1)
+            : list.Where(x => StringCompareHelpers.AllStringsStartsWith(x!.Keywords, parameter.Tokens)).ElementAtOrDefault(parameter.Count - 1);
     }
 
     public static IEnumerable<T> FindAllByName<T>(IEnumerable<T> list, ICommandParameter parameter, bool perfectMatch = false)
         where T : IEntity
     {
         return perfectMatch
-            ? list.Where(x => StringCompareHelpers.StringListsEquals(x.Keywords, parameter.Tokens))
-            : list.Where(x => StringCompareHelpers.StringListsStartsWith(x.Keywords, parameter.Tokens));
+            ? list.Where(x => StringCompareHelpers.AllStringsEquals(x.Keywords, parameter.Tokens))
+            : list.Where(x => StringCompareHelpers.AllStringsStartsWith(x.Keywords, parameter.Tokens));
     }
 
     public static IEnumerable<T> FindAllByName<T>(IEnumerable<T> list, string parameter, bool perfectMatch = false)
         where T : IEntity
     {
         return perfectMatch
-            ? list.Where(x => StringCompareHelpers.StringListEquals(x.Keywords, parameter))
-            : list.Where(x => StringCompareHelpers.StringListStartsWith(x.Keywords, parameter));
+            ? list.Where(x => StringCompareHelpers.AnyStringEquals(x.Keywords, parameter))
+            : list.Where(x => StringCompareHelpers.AnyStringStartsWith(x.Keywords, parameter));
     }
 
     //public static IEnumerable<IPlayer> FindAllByName(IEnumerable<IPlayer> list, CommandParameter parameter, bool perfectMatch = false)
@@ -114,8 +114,8 @@ public static class FindHelpers
         where TEntity : IEntity
     {
         return perfectMatch
-            ? collection.Where(x => StringCompareHelpers.StringListsEquals(getItemFunc(x).Keywords, parameter.Tokens)).ElementAtOrDefault(parameter.Count - 1)
-            : collection.Where(x => StringCompareHelpers.StringListsStartsWith(getItemFunc(x).Keywords, parameter.Tokens)).ElementAtOrDefault(parameter.Count - 1);
+            ? collection.Where(x => StringCompareHelpers.AllStringsEquals(getItemFunc(x).Keywords, parameter.Tokens)).ElementAtOrDefault(parameter.Count - 1)
+            : collection.Where(x => StringCompareHelpers.AllStringsStartsWith(getItemFunc(x).Keywords, parameter.Tokens)).ElementAtOrDefault(parameter.Count - 1);
     }
 
     // FindLocation

--- a/Mud.Server.Interfaces/Ability/IAbilityInfo.cs
+++ b/Mud.Server.Interfaces/Ability/IAbilityInfo.cs
@@ -28,7 +28,8 @@ public enum AbilityTypes
 {
     Skill,
     Spell,
-    Passive
+    Passive,
+    Weapon
 }
 
 [Flags]

--- a/Mud.Server.Interfaces/AbilityGroup/IAbilityGroup.cs
+++ b/Mud.Server.Interfaces/AbilityGroup/IAbilityGroup.cs
@@ -1,0 +1,10 @@
+﻿namespace Mud.Server.Interfaces.AbilityGroup
+{
+    public interface IAbilityGroup
+    {
+        string Name { get; }
+
+        IEnumerable<string> AbilityGroups { get; }
+        IEnumerable<string> Abilities { get; }
+    }
+}

--- a/Mud.Server.Interfaces/AbilityGroup/IAbilityGroupInfo.cs
+++ b/Mud.Server.Interfaces/AbilityGroup/IAbilityGroupInfo.cs
@@ -1,0 +1,12 @@
+﻿using Mud.Server.Interfaces.Ability;
+
+namespace Mud.Server.Interfaces.AbilityGroup
+{
+    public interface IAbilityGroupInfo
+    {
+        string Name { get; }
+
+        IEnumerable<IAbilityGroupInfo> AbilityGroupInfos { get; }
+        IEnumerable<IAbilityInfo> AbilityInfos { get; }
+    }
+}

--- a/Mud.Server.Interfaces/AbilityGroup/IAbilityGroupLearned.cs
+++ b/Mud.Server.Interfaces/AbilityGroup/IAbilityGroupLearned.cs
@@ -1,0 +1,15 @@
+﻿using Mud.Domain.SerializationData;
+
+namespace Mud.Server.Interfaces.AbilityGroup
+{
+    public interface IAbilityGroupLearned
+    {
+        string Name { get; }
+
+        int Cost { get; }
+
+        IAbilityGroupInfo AbilityGroupInfo { get; }
+
+        LearnedAbilityGroupData MapLearnedAbilityGroupData();
+    }
+}

--- a/Mud.Server.Interfaces/AbilityGroup/IAbilityGroupManager.cs
+++ b/Mud.Server.Interfaces/AbilityGroup/IAbilityGroupManager.cs
@@ -1,0 +1,7 @@
+﻿namespace Mud.Server.Interfaces.AbilityGroup
+{
+    public interface IAbilityGroupManager
+    {
+        IAbilityGroupInfo? this[string abilityGroupName] { get; }
+    }
+}

--- a/Mud.Server.Interfaces/AbilityGroup/IAbilityGroupUsage.cs
+++ b/Mud.Server.Interfaces/AbilityGroup/IAbilityGroupUsage.cs
@@ -1,0 +1,9 @@
+﻿namespace Mud.Server.Interfaces.AbilityGroup
+{
+    public interface IAbilityGroupUsage
+    {
+        string Name { get; }
+        int Cost { get; }
+        IAbilityGroupInfo AbilityGroupInfo { get; }
+    }
+}

--- a/Mud.Server.Interfaces/Character/IPlayableCharacter.cs
+++ b/Mud.Server.Interfaces/Character/IPlayableCharacter.cs
@@ -1,5 +1,7 @@
 ﻿using Mud.Domain;
 using Mud.Domain.SerializationData;
+using Mud.Server.Interfaces.Ability;
+using Mud.Server.Interfaces.AbilityGroup;
 using Mud.Server.Interfaces.Item;
 using Mud.Server.Interfaces.Player;
 using Mud.Server.Interfaces.Quest;
@@ -62,6 +64,7 @@ public interface IPlayableCharacter : ICharacter
     void GainExperience(long experience); // add/substract experience
 
     // Ability
+    IEnumerable<IAbilityGroupLearned> LearnedAbilityGroups { get; }
     bool CheckAbilityImprove(string abilityName, bool abilityUsedSuccessfully, int multiplier);
 
     // Immortality

--- a/Mud.Server.Interfaces/Class/IClass.cs
+++ b/Mud.Server.Interfaces/Class/IClass.cs
@@ -1,5 +1,6 @@
 ﻿using Mud.Domain;
 using Mud.Server.Interfaces.Ability;
+using Mud.Server.Interfaces.AbilityGroup;
 
 namespace Mud.Server.Interfaces.Class;
 
@@ -17,8 +18,16 @@ public interface IClass
 
     // Will give a +2 to this attribute
     BasicAttributes PrimeAttribute { get; }
+
     // Abilities available for this class
-    IEnumerable<IAbilityUsage> Abilities { get; }
+    IEnumerable<IAbilityUsage> AvailableAbilities { get; }
+    // Ability groups available for this class
+    IEnumerable<IAbilityGroupUsage> AvailableAbilityGroups { get; }
+    // Ability groups given for free during creation
+    IEnumerable<IAbilityGroupUsage> BasicAbilityGroups { get; }
+    // Ability groups given when no customization is done
+    IEnumerable<IAbilityGroupUsage> DefaultAbilityGroups { get; }
+
     // Max practice percentage (learned in KnownAbility)
     int MaxPracticePercentage { get; }
 

--- a/Mud.Server.POC/Classes/Druid.cs
+++ b/Mud.Server.POC/Classes/Druid.cs
@@ -4,6 +4,7 @@ using Mud.Common.Attributes;
 using Mud.Domain;
 using Mud.Server.Class;
 using Mud.Server.Interfaces.Ability;
+using Mud.Server.Interfaces.AbilityGroup;
 using Mud.Server.Interfaces.Class;
 
 namespace Mud.Server.POC.Classes;
@@ -69,8 +70,8 @@ public class Druid : ClassBase
 
     #endregion
 
-    public Druid(ILogger<Druid> logger, IAbilityManager abilityManager)
-        : base(logger, abilityManager)
+    public Druid(ILogger<Druid> logger, IAbilityManager abilityManager, IAbilityGroupManager abilityGroupManager)
+        : base(logger, abilityManager, abilityGroupManager)
     {
         // Test class with all skills + Passive
         foreach (var abilityInfo in AbilityManager.Abilities.Where(x => x.Type == AbilityTypes.Skill))
@@ -78,7 +79,7 @@ public class Druid : ClassBase
                 AddAbility(20, abilityInfo.Name, Domain.ResourceKinds.Mana, 35, CostAmountOperators.Fixed, 1);
             else
                 AddSkill(20, abilityInfo.Name, 1);
-        foreach (var abilityInfo in AbilityManager.Abilities.Where(x => x.Type == AbilityTypes.Passive))
+        foreach (var abilityInfo in AbilityManager.Abilities.Where(x => x.Type == AbilityTypes.Passive || x.Type == AbilityTypes.Weapon))
             AddAbility(10, abilityInfo.Name, null, 0, CostAmountOperators.None, 1);
     }
 }

--- a/Mud.Server.Rom24/AbilityGroups/Attack.cs
+++ b/Mud.Server.Rom24/AbilityGroups/Attack.cs
@@ -1,0 +1,27 @@
+﻿using Mud.Common.Attributes;
+using Mud.Server.Ability.AbilityGroup;
+using Mud.Server.Interfaces.AbilityGroup;
+
+namespace Mud.Server.Rom24.AbilityGroups
+{
+    [Export(typeof(IAbilityGroup)), Shared]
+    public class Attack : AbilityGroupBase
+    {
+        public Attack()
+        {
+            AddAbility("demonfire");
+            AddAbility("dispel evil");
+            AddAbility("dispel good");
+            AddAbility("earthquake");
+            AddAbility("flamestrike");
+            AddAbility("heat metal");
+            AddAbility("ray of truth");
+        }
+
+        #region IAbilityGroup
+
+        public override string Name => "attack";
+
+        #endregion
+    }
+}

--- a/Mud.Server.Rom24/AbilityGroups/Beguiling.cs
+++ b/Mud.Server.Rom24/AbilityGroups/Beguiling.cs
@@ -1,0 +1,23 @@
+﻿using Mud.Common.Attributes;
+using Mud.Server.Ability.AbilityGroup;
+using Mud.Server.Interfaces.AbilityGroup;
+
+namespace Mud.Server.Rom24.AbilityGroups
+{
+    [Export(typeof(IAbilityGroup)), Shared]
+    public class Beguiling : AbilityGroupBase
+    {
+        public Beguiling()
+        {
+            AddAbility("calm");
+            AddAbility("charm person");
+            AddAbility("sleep");
+        }
+
+        #region IAbilityGroup
+
+        public override string Name => "beguiling";
+
+        #endregion
+    }
+}

--- a/Mud.Server.Rom24/AbilityGroups/Benedictions.cs
+++ b/Mud.Server.Rom24/AbilityGroups/Benedictions.cs
@@ -1,0 +1,25 @@
+﻿using Mud.Common.Attributes;
+using Mud.Server.Ability.AbilityGroup;
+using Mud.Server.Interfaces.AbilityGroup;
+
+namespace Mud.Server.Rom24.AbilityGroups
+{
+    [Export(typeof(IAbilityGroup)), Shared]
+    public class Benedictions : AbilityGroupBase
+    {
+        public Benedictions()
+        {
+            AddAbility("bless");
+            AddAbility("calm");
+            AddAbility("frenzy");
+            AddAbility("holy word");
+            AddAbility("remove curse");
+        }
+
+        #region IAbilityGroup
+
+        public override string Name => "benedictions";
+
+        #endregion
+    }
+}

--- a/Mud.Server.Rom24/AbilityGroups/ClericBasics.cs
+++ b/Mud.Server.Rom24/AbilityGroups/ClericBasics.cs
@@ -1,0 +1,21 @@
+﻿using Mud.Common.Attributes;
+using Mud.Server.Ability.AbilityGroup;
+using Mud.Server.Interfaces.AbilityGroup;
+
+namespace Mud.Server.Rom24.AbilityGroups
+{
+    [Export(typeof(IAbilityGroup)), Shared]
+    public class ClericBasics : AbilityGroupBase
+    {
+        public ClericBasics()
+        {
+            AddAbility("mace");
+        }
+
+        #region IAbilityGroup
+
+        public override string Name => "cleric basics";
+
+        #endregion
+    }
+}

--- a/Mud.Server.Rom24/AbilityGroups/ClericDefault.cs
+++ b/Mud.Server.Rom24/AbilityGroups/ClericDefault.cs
@@ -1,0 +1,33 @@
+﻿using Mud.Common.Attributes;
+using Mud.Server.Ability.AbilityGroup;
+using Mud.Server.Interfaces.AbilityGroup;
+
+namespace Mud.Server.Rom24.AbilityGroups
+{
+    [Export(typeof(IAbilityGroup)), Shared]
+    public class ClericDefault : AbilityGroupBase
+    {
+        public ClericDefault()
+        {
+            AddAbility("flail");
+            AddAbility("shield block");
+
+            AddAbilityGroup("attack");
+            AddAbilityGroup("creation");
+            AddAbilityGroup("curative");
+            AddAbilityGroup("benedictions");
+            AddAbilityGroup("detection");
+            AddAbilityGroup("healing");
+            AddAbilityGroup("maladictions");
+            AddAbilityGroup("protective");
+            AddAbilityGroup("transportation");
+            AddAbilityGroup("weather");
+        }
+
+        #region IAbilityGroup
+
+        public override string Name => "cleric default";
+
+        #endregion
+    }
+}

--- a/Mud.Server.Rom24/AbilityGroups/Combat.cs
+++ b/Mud.Server.Rom24/AbilityGroups/Combat.cs
@@ -1,0 +1,29 @@
+﻿using Mud.Common.Attributes;
+using Mud.Server.Ability.AbilityGroup;
+using Mud.Server.Interfaces.AbilityGroup;
+
+namespace Mud.Server.Rom24.AbilityGroups
+{
+    [Export(typeof(IAbilityGroup)), Shared]
+    public class Combat : AbilityGroupBase
+    {
+        public Combat()
+        {
+            AddAbility("acid blast");
+            AddAbility("burning hands");
+            AddAbility("chain lightning");
+            AddAbility("chill touch");
+            AddAbility("colour spray");
+            AddAbility("fireball");
+            AddAbility("lightning bolt");
+            AddAbility("magic missile");
+            AddAbility("shocking grasp");
+        }
+
+        #region IAbilityGroup
+
+        public override string Name => "combat";
+
+        #endregion
+    }
+}

--- a/Mud.Server.Rom24/AbilityGroups/Creation.cs
+++ b/Mud.Server.Rom24/AbilityGroups/Creation.cs
@@ -1,0 +1,26 @@
+﻿using Mud.Common.Attributes;
+using Mud.Server.Ability.AbilityGroup;
+using Mud.Server.Interfaces.AbilityGroup;
+
+namespace Mud.Server.Rom24.AbilityGroups
+{
+    [Export(typeof(IAbilityGroup)), Shared]
+    public class Creation : AbilityGroupBase
+    {
+        public Creation()
+        {
+            AddAbility("continual light");
+            AddAbility("create food");
+            AddAbility("create spring");
+            AddAbility("create water");
+            AddAbility("create rose");
+            AddAbility("floating disc");
+        }
+
+        #region IAbilityGroup
+
+        public override string Name => "creation";
+
+        #endregion
+    }
+}

--- a/Mud.Server.Rom24/AbilityGroups/Curative.cs
+++ b/Mud.Server.Rom24/AbilityGroups/Curative.cs
@@ -1,0 +1,23 @@
+﻿using Mud.Common.Attributes;
+using Mud.Server.Ability.AbilityGroup;
+using Mud.Server.Interfaces.AbilityGroup;
+
+namespace Mud.Server.Rom24.AbilityGroups
+{
+    [Export(typeof(IAbilityGroup)), Shared]
+    public class Curative : AbilityGroupBase
+    {
+        public Curative()
+        {
+            AddAbility("cure blindness");
+            AddAbility("cure disease");
+            AddAbility("cure poison");
+        }
+
+        #region IAbilityGroup
+
+        public override string Name => "curative";
+
+        #endregion
+    }
+}

--- a/Mud.Server.Rom24/AbilityGroups/Detection.cs
+++ b/Mud.Server.Rom24/AbilityGroups/Detection.cs
@@ -1,0 +1,30 @@
+﻿using Mud.Common.Attributes;
+using Mud.Server.Ability.AbilityGroup;
+using Mud.Server.Interfaces.AbilityGroup;
+
+namespace Mud.Server.Rom24.AbilityGroups
+{
+    [Export(typeof(IAbilityGroup)), Shared]
+    public class Detection : AbilityGroupBase
+    {
+        public Detection()
+        {
+            AddAbility("detect evil");
+            AddAbility("detect good");
+            AddAbility("detect hidden");
+            AddAbility("detect invis");
+            AddAbility("detect magic");
+            AddAbility("detect poison");
+            AddAbility("farsight");
+            AddAbility("identify");
+            AddAbility("know alignment");
+            AddAbility("locate object");
+        }
+
+        #region IAbilityGroup
+
+        public override string Name => "detection";
+
+        #endregion
+    }
+}

--- a/Mud.Server.Rom24/AbilityGroups/Draconian.cs
+++ b/Mud.Server.Rom24/AbilityGroups/Draconian.cs
@@ -1,0 +1,25 @@
+﻿using Mud.Common.Attributes;
+using Mud.Server.Ability.AbilityGroup;
+using Mud.Server.Interfaces.AbilityGroup;
+
+namespace Mud.Server.Rom24.AbilityGroups
+{
+    [Export(typeof(IAbilityGroup)), Shared]
+    public class Draconian : AbilityGroupBase
+    {
+        public Draconian()
+        {
+            AddAbility("acid breath");
+            AddAbility("fire breath");
+            AddAbility("frost breath");
+            AddAbility("gas breath");
+            AddAbility("lightning breath");
+        }
+
+        #region IAbilityGroup
+
+        public override string Name => "draconian";
+
+        #endregion
+    }
+}

--- a/Mud.Server.Rom24/AbilityGroups/Enchantment.cs
+++ b/Mud.Server.Rom24/AbilityGroups/Enchantment.cs
@@ -1,0 +1,24 @@
+﻿using Mud.Common.Attributes;
+using Mud.Server.Ability.AbilityGroup;
+using Mud.Server.Interfaces.AbilityGroup;
+
+namespace Mud.Server.Rom24.AbilityGroups
+{
+    [Export(typeof(IAbilityGroup)), Shared]
+    public class Enchantment : AbilityGroupBase
+    {
+        public Enchantment()
+        {
+            AddAbility("enchant armor");
+            AddAbility("enchant weapon");
+            AddAbility("fireproof");
+            AddAbility("recharge");
+        }
+
+        #region IAbilityGroup
+
+        public override string Name => "enchantment";
+
+        #endregion
+    }
+}

--- a/Mud.Server.Rom24/AbilityGroups/Enhancement.cs
+++ b/Mud.Server.Rom24/AbilityGroups/Enhancement.cs
@@ -1,0 +1,24 @@
+﻿using Mud.Common.Attributes;
+using Mud.Server.Ability.AbilityGroup;
+using Mud.Server.Interfaces.AbilityGroup;
+
+namespace Mud.Server.Rom24.AbilityGroups
+{
+    [Export(typeof(IAbilityGroup)), Shared]
+    public class Enhancement : AbilityGroupBase
+    {
+        public Enhancement()
+        {
+            AddAbility("giant strength");
+            AddAbility("haste");
+            AddAbility("infravision");
+            AddAbility("refresh");
+        }
+
+        #region IAbilityGroup
+
+        public override string Name => "enhancement";
+
+        #endregion
+    }
+}

--- a/Mud.Server.Rom24/AbilityGroups/Harmful.cs
+++ b/Mud.Server.Rom24/AbilityGroups/Harmful.cs
@@ -1,0 +1,24 @@
+﻿using Mud.Common.Attributes;
+using Mud.Server.Ability.AbilityGroup;
+using Mud.Server.Interfaces.AbilityGroup;
+
+namespace Mud.Server.Rom24.AbilityGroups
+{
+    [Export(typeof(IAbilityGroup)), Shared]
+    public class Harmful : AbilityGroupBase
+    {
+        public Harmful()
+        {
+            AddAbility("cause critical");
+            AddAbility("cause light");
+            AddAbility("cause serious");
+            AddAbility("harm");
+        }
+
+        #region IAbilityGroup
+
+        public override string Name => "harmful";
+
+        #endregion
+    }
+}

--- a/Mud.Server.Rom24/AbilityGroups/Healing.cs
+++ b/Mud.Server.Rom24/AbilityGroups/Healing.cs
@@ -1,0 +1,26 @@
+﻿using Mud.Common.Attributes;
+using Mud.Server.Ability.AbilityGroup;
+using Mud.Server.Interfaces.AbilityGroup;
+
+namespace Mud.Server.Rom24.AbilityGroups
+{
+    [Export(typeof(IAbilityGroup)), Shared]
+    public class Healing : AbilityGroupBase
+    {
+        public Healing()
+        {
+            AddAbility("cure critical");
+            AddAbility("cure light");
+            AddAbility("cure serious");
+            AddAbility("heal");
+            AddAbility("mass healing");
+            AddAbility("refresh");
+        }
+
+        #region IAbilityGroup
+
+        public override string Name => "healing";
+
+        #endregion
+    }
+}

--- a/Mud.Server.Rom24/AbilityGroups/Illusion.cs
+++ b/Mud.Server.Rom24/AbilityGroups/Illusion.cs
@@ -1,0 +1,23 @@
+﻿using Mud.Common.Attributes;
+using Mud.Server.Ability.AbilityGroup;
+using Mud.Server.Interfaces.AbilityGroup;
+
+namespace Mud.Server.Rom24.AbilityGroups
+{
+    [Export(typeof(IAbilityGroup)), Shared]
+    public class Illusion : AbilityGroupBase
+    {
+        public Illusion()
+        {
+            AddAbility("invis");
+            AddAbility("mass invis");
+            AddAbility("ventriloquate");
+        }
+
+        #region IAbilityGroup
+
+        public override string Name => "illusion";
+
+        #endregion
+    }
+}

--- a/Mud.Server.Rom24/AbilityGroups/MageBasics.cs
+++ b/Mud.Server.Rom24/AbilityGroups/MageBasics.cs
@@ -1,0 +1,21 @@
+﻿using Mud.Common.Attributes;
+using Mud.Server.Ability.AbilityGroup;
+using Mud.Server.Interfaces.AbilityGroup;
+
+namespace Mud.Server.Rom24.AbilityGroups
+{
+    [Export(typeof(IAbilityGroup)), Shared]
+    public class MageBasics : AbilityGroupBase
+    {
+        public MageBasics()
+        {
+            AddAbility("dagger");
+        }
+
+        #region IAbilityGroup
+
+        public override string Name => "mage basics";
+
+        #endregion
+    }
+}

--- a/Mud.Server.Rom24/AbilityGroups/MageDefault.cs
+++ b/Mud.Server.Rom24/AbilityGroups/MageDefault.cs
@@ -1,0 +1,31 @@
+﻿using Mud.Common.Attributes;
+using Mud.Server.Ability.AbilityGroup;
+using Mud.Server.Interfaces.AbilityGroup;
+
+namespace Mud.Server.Rom24.AbilityGroups
+{
+    [Export(typeof(IAbilityGroup)), Shared]
+    public class MageDefault : AbilityGroupBase
+    {
+        public MageDefault()
+        {
+            AddAbility("lore");
+
+            AddAbilityGroup("beguiling");
+            AddAbilityGroup("combat");
+            AddAbilityGroup("detection");
+            AddAbilityGroup("enhancement");
+            AddAbilityGroup("illusion");
+            AddAbilityGroup("maladictions");
+            AddAbilityGroup("protective");
+            AddAbilityGroup("transportation");
+            AddAbilityGroup("weather");
+        }
+
+        #region IAbilityGroup
+
+        public override string Name => "mage default";
+
+        #endregion
+    }
+}

--- a/Mud.Server.Rom24/AbilityGroups/Maladictions.cs
+++ b/Mud.Server.Rom24/AbilityGroups/Maladictions.cs
@@ -1,0 +1,28 @@
+﻿using Mud.Common.Attributes;
+using Mud.Server.Ability.AbilityGroup;
+using Mud.Server.Interfaces.AbilityGroup;
+
+namespace Mud.Server.Rom24.AbilityGroups
+{
+    [Export(typeof(IAbilityGroup)), Shared]
+    public class Maladictions : AbilityGroupBase
+    {
+        public Maladictions()
+        {
+            AddAbility("blindness");
+            AddAbility("change sex");
+            AddAbility("curse");
+            AddAbility("energy drain");
+            AddAbility("plague");
+            AddAbility("poison");
+            AddAbility("slow");
+            AddAbility("weaken");
+        }
+
+        #region IAbilityGroup
+
+        public override string Name => "maladictions";
+
+        #endregion
+    }
+}

--- a/Mud.Server.Rom24/AbilityGroups/Protective.cs
+++ b/Mud.Server.Rom24/AbilityGroups/Protective.cs
@@ -1,0 +1,29 @@
+﻿using Mud.Common.Attributes;
+using Mud.Server.Ability.AbilityGroup;
+using Mud.Server.Interfaces.AbilityGroup;
+
+namespace Mud.Server.Rom24.AbilityGroups
+{
+    [Export(typeof(IAbilityGroup)), Shared]
+    public class Protective : AbilityGroupBase
+    {
+        public Protective()
+        {
+            AddAbility("armor");
+            AddAbility("cancellation");
+            AddAbility("dispel magic");
+            AddAbility("fireproof");
+            AddAbility("protection evil");
+            AddAbility("protection good");
+            AddAbility("sanctuary");
+            AddAbility("shield");
+            AddAbility("stone skin");
+        }
+
+        #region IAbilityGroup
+
+        public override string Name => "protective";
+
+        #endregion
+    }
+}

--- a/Mud.Server.Rom24/AbilityGroups/RomBasics.cs
+++ b/Mud.Server.Rom24/AbilityGroups/RomBasics.cs
@@ -1,0 +1,24 @@
+﻿using Mud.Common.Attributes;
+using Mud.Server.Ability.AbilityGroup;
+using Mud.Server.Interfaces.AbilityGroup;
+
+namespace Mud.Server.Rom24.AbilityGroups
+{
+    [Export(typeof(IAbilityGroup)), Shared]
+    public class RomBasics : AbilityGroupBase
+    {
+        public RomBasics()
+        {
+            AddAbility("scrolls");
+            AddAbility("staves");
+            AddAbility("wands");
+            AddAbility("recall");
+        }
+
+        #region IAbilityGroup
+
+        public override string Name => "rom basics";
+
+        #endregion
+    }
+}

--- a/Mud.Server.Rom24/AbilityGroups/ThiefBasics.cs
+++ b/Mud.Server.Rom24/AbilityGroups/ThiefBasics.cs
@@ -1,0 +1,22 @@
+﻿using Mud.Common.Attributes;
+using Mud.Server.Ability.AbilityGroup;
+using Mud.Server.Interfaces.AbilityGroup;
+
+namespace Mud.Server.Rom24.AbilityGroups
+{
+    [Export(typeof(IAbilityGroup)), Shared]
+    public class ThiefBasics : AbilityGroupBase
+    {
+        public ThiefBasics()
+        {
+            AddAbility("dagger");
+            AddAbility("steal");
+        }
+
+        #region IAbilityGroup
+
+        public override string Name => "thief basics";
+
+        #endregion
+    }
+}

--- a/Mud.Server.Rom24/AbilityGroups/ThiefDefault.cs
+++ b/Mud.Server.Rom24/AbilityGroups/ThiefDefault.cs
@@ -1,0 +1,31 @@
+﻿using Mud.Common.Attributes;
+using Mud.Server.Ability.AbilityGroup;
+using Mud.Server.Interfaces.AbilityGroup;
+
+namespace Mud.Server.Rom24.AbilityGroups
+{
+    [Export(typeof(IAbilityGroup)), Shared]
+    public class ThiefDefault : AbilityGroupBase
+    {
+        public ThiefDefault()
+        {
+            AddAbility("mace");
+            AddAbility("sword");
+            AddAbility("backstab");
+            AddAbility("disarm");
+            AddAbility("dodge");
+            AddAbility("second attack");
+            AddAbility("trip");
+            AddAbility("hide");
+            AddAbility("peek");
+            AddAbility("pick lock");
+            AddAbility("sneak");
+        }
+
+        #region IAbilityGroup
+
+        public override string Name => "thief default";
+
+        #endregion
+    }
+}

--- a/Mud.Server.Rom24/AbilityGroups/Transportation.cs
+++ b/Mud.Server.Rom24/AbilityGroups/Transportation.cs
@@ -1,0 +1,28 @@
+﻿using Mud.Common.Attributes;
+using Mud.Server.Ability.AbilityGroup;
+using Mud.Server.Interfaces.AbilityGroup;
+
+namespace Mud.Server.Rom24.AbilityGroups
+{
+    [Export(typeof(IAbilityGroup)), Shared]
+    public class Transportation : AbilityGroupBase
+    {
+        public Transportation()
+        {
+            AddAbility("fly");
+            AddAbility("gate");
+            AddAbility("nexus");
+            AddAbility("pass door");
+            AddAbility("portal");
+            AddAbility("summon");
+            AddAbility("teleport");
+            AddAbility("word of recall");
+        }
+
+        #region IAbilityGroup
+
+        public override string Name => "transportation";
+
+        #endregion
+    }
+}

--- a/Mud.Server.Rom24/AbilityGroups/WarriorBasics.cs
+++ b/Mud.Server.Rom24/AbilityGroups/WarriorBasics.cs
@@ -1,0 +1,22 @@
+﻿using Mud.Common.Attributes;
+using Mud.Server.Ability.AbilityGroup;
+using Mud.Server.Interfaces.AbilityGroup;
+
+namespace Mud.Server.Rom24.AbilityGroups
+{
+    [Export(typeof(IAbilityGroup)), Shared]
+    public class WarriorBasics : AbilityGroupBase
+    {
+        public WarriorBasics()
+        {
+            AddAbility("sword");
+            AddAbility("second attack");
+        }
+
+        #region IAbilityGroup
+
+        public override string Name => "warrior basics";
+
+        #endregion
+    }
+}

--- a/Mud.Server.Rom24/AbilityGroups/WarriorDefault.cs
+++ b/Mud.Server.Rom24/AbilityGroups/WarriorDefault.cs
@@ -1,0 +1,29 @@
+﻿using Mud.Common.Attributes;
+using Mud.Server.Ability.AbilityGroup;
+using Mud.Server.Interfaces.AbilityGroup;
+
+namespace Mud.Server.Rom24.AbilityGroups
+{
+    [Export(typeof(IAbilityGroup)), Shared]
+    public class WarriorDefault : AbilityGroupBase
+    {
+        public WarriorDefault()
+        {
+            AddAbility("shield block");
+            AddAbility("bash");
+            AddAbility("disarm");
+            AddAbility("enhanced damage");
+            AddAbility("parry");
+            AddAbility("rescue");
+            AddAbility("third attack");
+
+            AddAbilityGroup("weaponsmaster");
+        }
+
+        #region IAbilityGroup
+
+        public override string Name => "warrior default";
+
+        #endregion
+    }
+}

--- a/Mud.Server.Rom24/AbilityGroups/Weaponsmaster.cs
+++ b/Mud.Server.Rom24/AbilityGroups/Weaponsmaster.cs
@@ -1,0 +1,28 @@
+﻿using Mud.Common.Attributes;
+using Mud.Server.Ability.AbilityGroup;
+using Mud.Server.Interfaces.AbilityGroup;
+
+namespace Mud.Server.Rom24.AbilityGroups
+{
+    [Export(typeof(IAbilityGroup)), Shared]
+    public class Weaponsmaster : AbilityGroupBase
+    {
+        public Weaponsmaster()
+        {
+            AddAbility("axe");
+            AddAbility("dagger");
+            AddAbility("flail");
+            AddAbility("mace");
+            AddAbility("polearm");
+            AddAbility("spear");
+            AddAbility("sword");
+            AddAbility("whip");
+        }
+
+        #region IAbilityGroup
+
+        public override string Name => "weaponsmaster";
+
+        #endregion
+    }
+}

--- a/Mud.Server.Rom24/AbilityGroups/Weather.cs
+++ b/Mud.Server.Rom24/AbilityGroups/Weather.cs
@@ -1,0 +1,25 @@
+﻿using Mud.Common.Attributes;
+using Mud.Server.Ability.AbilityGroup;
+using Mud.Server.Interfaces.AbilityGroup;
+
+namespace Mud.Server.Rom24.AbilityGroups
+{
+    [Export(typeof(IAbilityGroup)), Shared]
+    public class Weather : AbilityGroupBase
+    {
+        public Weather()
+        {
+            AddAbility("call lightning");
+            AddAbility("control weather");
+            AddAbility("faerie fire");
+            AddAbility("faerie fog");
+            AddAbility("lightning bolt");
+        }
+
+        #region IAbilityGroup
+
+        public override string Name => "weather";
+
+        #endregion
+    }
+}

--- a/Mud.Server.Rom24/Classes/Cleric.cs
+++ b/Mud.Server.Rom24/Classes/Cleric.cs
@@ -4,6 +4,7 @@ using Mud.Domain;
 using Mud.Server.Class;
 using Mud.Server.Common;
 using Mud.Server.Interfaces.Ability;
+using Mud.Server.Interfaces.AbilityGroup;
 using Mud.Server.Interfaces.Class;
 
 namespace Mud.Server.Rom24.Classes;
@@ -20,8 +21,8 @@ be purchased, many at a very dear cost.")]
 [Export(typeof(IClass)), Shared]
 public class Cleric : ClassBase
 {
-    public Cleric(ILogger<Cleric> logger, IAbilityManager abilityManager)
-        : base(logger, abilityManager)
+    public Cleric(ILogger<Cleric> logger, IAbilityManager abilityManager, IAbilityGroupManager abilityGroupManager)
+        : base(logger, abilityManager, abilityGroupManager)
     {
         AddPassive(1, "axe", 6);
         AddPassive(1, "dagger", 3);
@@ -32,7 +33,7 @@ public class Cleric : ClassBase
         AddPassive(1, "spear", 4);
         AddPassive(1, "sword", 6);
         AddPassive(1, "whip", 5);
-        AddSkill(1, "recall", 2, 40);
+        AddSkill(1, "recall", 2, 50);
         AddSkill(1, "scrolls", 3);
         AddSkill(1, "staves", 3);
         AddSkill(1, "wands", 3);
@@ -125,6 +126,22 @@ public class Cleric : ClassBase
         AddSpell(40, "stone skin", Domain.ResourceKinds.Mana, 12, CostAmountOperators.Fixed, 1);
         AddSpell(43, "gas breath", Domain.ResourceKinds.Mana, 175, CostAmountOperators.Fixed, 1);
         AddSpell(45, "fire breath", Domain.ResourceKinds.Mana, 200, CostAmountOperators.Fixed, 1);
+
+        AddAbilityGroup("weaponsmaster", 40);
+        AddAbilityGroup("attack", 5);
+        AddAbilityGroup("benedictions", 4);
+        AddAbilityGroup("creation", 4);
+        AddAbilityGroup("curative", 4);
+        AddAbilityGroup("detection", 3);
+        AddAbilityGroup("harmful", 4);
+        AddAbilityGroup("healing", 3);
+        AddAbilityGroup("maladictions", 5);
+        AddAbilityGroup("protective", 4);
+        AddAbilityGroup("transportation", 4);
+        AddAbilityGroup("weather", 4);
+        AddBasicAbilityGroup("rom basics");
+        AddBasicAbilityGroup("cleric basics");
+        AddDefaultAbilityGroup("cleric default", 40);
     }
 
     #region IClass

--- a/Mud.Server.Rom24/Classes/Mage.cs
+++ b/Mud.Server.Rom24/Classes/Mage.cs
@@ -4,6 +4,7 @@ using Mud.Domain;
 using Mud.Server.Class;
 using Mud.Server.Common;
 using Mud.Server.Interfaces.Ability;
+using Mud.Server.Interfaces.AbilityGroup;
 using Mud.Server.Interfaces.Class;
 
 namespace Mud.Server.Rom24.Classes;
@@ -20,8 +21,8 @@ purchased, at a very high rate.")]
 [Export(typeof(IClass)), Shared]
 public class Mage : ClassBase
 {
-    public Mage(ILogger<Mage> logger, IAbilityManager abilityManager)
-        : base(logger, abilityManager)
+    public Mage(ILogger<Mage> logger, IAbilityManager abilityManager, IAbilityGroupManager abilityGroupManager)
+        : base(logger, abilityManager, abilityGroupManager)
     {
         AddPassive(1, "axe", 6);
         AddPassive(1, "dagger", 2);
@@ -32,7 +33,7 @@ public class Mage : ClassBase
         AddPassive(1, "spear", 4);
         AddPassive(1, "sword", 5);
         AddPassive(1, "whip", 6);
-        AddSkill(1, "recall", 2, 40);
+        AddSkill(1, "recall", 2, 50);
         AddSkill(1, "scrolls", 2);
         AddSkill(1, "staves", 2);
         AddSkill(1, "wands", 2);
@@ -118,6 +119,23 @@ public class Mage : ClassBase
         AddSpell(40, "nexus", Domain.ResourceKinds.Mana, 150, CostAmountOperators.Fixed, 2);
         AddPassive(45, "enhanced damage", 10);
         AddSpell(48, "calm", Domain.ResourceKinds.Mana, 30, CostAmountOperators.Fixed, 1);
+
+        AddAbilityGroup("weaponsmaster", 40);
+        AddAbilityGroup("beguiling", 4);
+        AddAbilityGroup("combat", 6);
+        AddAbilityGroup("creation", 4);
+        AddAbilityGroup("detection", 3);
+        AddAbilityGroup("draconian", 8);
+        AddAbilityGroup("enchantment", 6);
+        AddAbilityGroup("enhancement", 5);
+        AddAbilityGroup("illusion", 4);
+        AddAbilityGroup("maladictions", 5);
+        AddAbilityGroup("protective", 4);
+        AddAbilityGroup("transportation", 4);
+        AddAbilityGroup("weather", 4);
+        AddBasicAbilityGroup("rom basics");
+        AddBasicAbilityGroup("mage basics");
+        AddDefaultAbilityGroup("mage default", 40);
     }
 
     #region IClass

--- a/Mud.Server.Rom24/Classes/Thief.cs
+++ b/Mud.Server.Rom24/Classes/Thief.cs
@@ -4,6 +4,7 @@ using Mud.Domain;
 using Mud.Server.Class;
 using Mud.Server.Common;
 using Mud.Server.Interfaces.Ability;
+using Mud.Server.Interfaces.AbilityGroup;
 using Mud.Server.Interfaces.Class;
 
 namespace Mud.Server.Rom24.Classes;
@@ -20,8 +21,8 @@ well.")]
 [Export(typeof(IClass)), Shared]
 public class Thief : ClassBase
 {
-    public Thief(ILogger<Thief> logger, IAbilityManager abilityManager)
-        : base(logger, abilityManager)
+    public Thief(ILogger<Thief> logger, IAbilityManager abilityManager, IAbilityGroupManager abilityGroupManager)
+        : base(logger, abilityManager, abilityGroupManager)
     {
         AddPassive(1, "axe", 5);
         AddPassive(1, "dagger", 2);
@@ -37,7 +38,7 @@ public class Thief : ClassBase
         AddPassive(1, "whip", 5);
         AddSkill(1, "backstab", 5);
         AddSkill(1, "hide", 4);
-        AddSkill(1, "recall", 2, 40);
+        AddSkill(1, "recall", 2, 50);
         AddSkill(1, "scrolls", 5);
         AddSkill(1, "staves", 5);
         AddSkill(1, "trip", 4);
@@ -126,6 +127,21 @@ public class Thief : ClassBase
         AddSpell(50, "calm", Domain.ResourceKinds.Mana, 30, CostAmountOperators.Fixed, 2);
         AddSpell(50, "fire breath", Domain.ResourceKinds.Mana, 200, CostAmountOperators.Fixed, 2);
         AddSpell(50, "nexus", Domain.ResourceKinds.Mana, 150, CostAmountOperators.Fixed, 4);
+
+        AddAbilityGroup("weaponsmaster", 40);
+        AddAbilityGroup("beguiling", 6);
+        AddAbilityGroup("combat", 10);
+        AddAbilityGroup("creation", 8);
+        AddAbilityGroup("detection", 6);
+        AddAbilityGroup("enhancement", 9);
+        AddAbilityGroup("illusion", 7);
+        AddAbilityGroup("maladictions", 9);
+        AddAbilityGroup("protective", 7);
+        AddAbilityGroup("transportation", 8);
+        AddAbilityGroup("weather", 8);
+        AddBasicAbilityGroup("rom basics");
+        AddBasicAbilityGroup("thief basics");
+        AddDefaultAbilityGroup("thief default", 40);
     }
 
     #region IClass

--- a/Mud.Server.Rom24/Classes/Warrior.cs
+++ b/Mud.Server.Rom24/Classes/Warrior.cs
@@ -4,6 +4,7 @@ using Mud.Domain;
 using Mud.Server.Class;
 using Mud.Server.Common;
 using Mud.Server.Interfaces.Ability;
+using Mud.Server.Interfaces.AbilityGroup;
 using Mud.Server.Interfaces.Class;
 
 namespace Mud.Server.Rom24.Classes;
@@ -18,8 +19,8 @@ Warriors begin with skill in the sword, and gain a second attack in combat.")]
 [Export(typeof(IClass)), Shared]
 public class Warrior : ClassBase
 {
-    public Warrior(ILogger<Warrior> logger, IAbilityManager abilityManager)
-        : base(logger, abilityManager)
+    public Warrior(ILogger<Warrior> logger, IAbilityManager abilityManager, IAbilityGroupManager abilityGroupManager)
+        : base(logger, abilityManager, abilityGroupManager)
     {
         AddPassive(1, "axe", 4);
         AddPassive(1, "dagger", 2);
@@ -33,7 +34,7 @@ public class Warrior : ClassBase
         AddPassive(1, "sword", 2);
         AddPassive(1, "whip", 4);
         AddSkill(1, "bash", 4);
-        AddSkill(1, "recall", 2, 40);
+        AddSkill(1, "recall", 2, 50);
         AddSkill(1, "rescue", 4);
         AddSkill(1, "scrolls", 8);
         AddSkill(1, "staves", 8);
@@ -130,6 +131,23 @@ public class Warrior : ClassBase
         AddSpell(46, "mass healing", Domain.ResourceKinds.Mana, 100, CostAmountOperators.Fixed, 4);
         AddSpell(47, "ray of truth", Domain.ResourceKinds.Mana, 20, CostAmountOperators.Fixed, 2);
         AddSpell(50, "gas breath", Domain.ResourceKinds.Mana, 175, CostAmountOperators.Fixed, 2);
+
+        AddAbilityGroup("weaponsmaster", 20);
+        AddAbilityGroup("attack", 8);
+        AddAbilityGroup("benedictions", 4);
+        AddAbilityGroup("combat", 9);
+        AddAbilityGroup("creation", 8);
+        AddAbilityGroup("curative", 8);
+        AddAbilityGroup("enhancement", 9);
+        AddAbilityGroup("harmful", 6);
+        AddAbilityGroup("healing", 6);
+        AddAbilityGroup("maladictions", 9);
+        AddAbilityGroup("protective", 8);
+        AddAbilityGroup("transportation", 9);
+        AddAbilityGroup("weather", 8);
+        AddBasicAbilityGroup("rom basics");
+        AddBasicAbilityGroup("warrior basics");
+        AddDefaultAbilityGroup("warrior default", 40);
     }
 
     #region IClass

--- a/Mud.Server.Rom24/Commands/PlayableCharacter/Outfit.cs
+++ b/Mud.Server.Rom24/Commands/PlayableCharacter/Outfit.cs
@@ -99,7 +99,7 @@ courtesy of the Mayor's warehouses.  Only empty equipment slots are affected.")]
             // shield
             if (Actor.GetEquipment(EquipmentSlots.OffHand) == null && Actor.GetEquipment(EquipmentSlots.MainHand) != null)
             {
-                var shield = ItemManager.AddItem<IItemShield>(Guid.NewGuid(), Options.MudSchool.Vest, Actor);
+                var shield = ItemManager.AddItem<IItemShield>(Guid.NewGuid(), Options.MudSchool.Shield, Actor);
                 if (shield != null)
                     WearItem(shield, false);
             }

--- a/Mud.Server.Rom24/Races/Elf.cs
+++ b/Mud.Server.Rom24/Races/Elf.cs
@@ -27,8 +27,8 @@ public class Elf : PlayableRaceBase
     public Elf(ILogger<Elf> logger, IFlagFactory flagFactory, IAbilityManager abilityManager)
         : base(logger, flagFactory, abilityManager)
     {
-        AddAbility("Sneak");
-        AddAbility("Hide");
+        AddAbility("sneak");
+        AddAbility("hide");
     }
 
     #region IRace/IPlayableRace

--- a/Mud.Server.Rom24/Races/Giant.cs
+++ b/Mud.Server.Rom24/Races/Giant.cs
@@ -27,8 +27,8 @@ public class Giant : PlayableRaceBase
     public Giant(ILogger<Giant> logger, IFlagFactory flagFactory, IAbilityManager abilityManager)
         : base(logger, flagFactory, abilityManager)
     {
-        AddAbility("Bash");
-        AddAbility("Fast healing");
+        AddAbility("bash");
+        AddAbility("fast healing");
     }
 
     #region IRace/IPlayableRace

--- a/Mud.Server.Tests/PlayableCharacters/SelfDeathDamageTests.cs
+++ b/Mud.Server.Tests/PlayableCharacters/SelfDeathDamageTests.cs
@@ -78,13 +78,14 @@ namespace Mud.Server.Tests.PlayableCharacters
                 AutoFlags = AutoFlags.None,
                 CurrentQuests = [],
                 LearnedAbilities = [],
+                LearnedAbilityGroups = [],
                 Conditions = [],
                 Aliases = [],
                 Cooldowns = [],
                 Pets = []
             };
 
-            var pc = new PlayableCharacter(loggerMock.Object, null, null, null, messageForwardOptions, worldOptions, null, null, roomManagerMock.Object, itemManagerMock.Object, characterManagerMock.Object, null, null, wiznetMock.Object, raceManagerMock.Object, classManagerMock.Object, null, damageModifierManagerMock.Object, null, flagFactoryMock.Object);
+            var pc = new PlayableCharacter(loggerMock.Object, null, null, null, messageForwardOptions, worldOptions, null, null, roomManagerMock.Object, itemManagerMock.Object, characterManagerMock.Object, null, null, wiznetMock.Object, raceManagerMock.Object, classManagerMock.Object, null, damageModifierManagerMock.Object, null, null, flagFactoryMock.Object);
             pc.Initialize(Guid.NewGuid(), pcData, playerMock.Object, roomMock.Object);
             pc.AbilityDamage(pc, 100000, SchoolTypes.Poison, "poison", false);
 

--- a/Mud.Server/Character/CharacterBase.cs
+++ b/Mud.Server/Character/CharacterBase.cs
@@ -11,6 +11,7 @@ using Mud.Server.Entity;
 using Mud.Server.Flags.Interfaces;
 using Mud.Server.Interfaces;
 using Mud.Server.Interfaces.Ability;
+using Mud.Server.Interfaces.AbilityGroup;
 using Mud.Server.Interfaces.Admin;
 using Mud.Server.Interfaces.Affect.Character;
 using Mud.Server.Interfaces.Aura;
@@ -2155,17 +2156,7 @@ public abstract class CharacterBase : EntityBase, ICharacter
         return Equipments.Where(x => x.Slot == EquipmentSlots.OffHand && x.Item == null).ElementAtOrDefault(countMainhand2H);
     }
 
-    protected virtual void RecomputeKnownAbilities()
-    {
-        // Add abilities from Class/Race/...
-
-        // Admins know every abilities
-        //if (ImpersonatedBy is IAdmin)
-        //    _knownAbilities.AddRange(AbilityManager.Abilities.Select(x => new AbilityAndLevel(1,x)));
-        //else
-        if (Class != null)
-            MergeAbilities(Class.Abilities, false);
-    }
+    protected abstract void RecomputeKnownAbilities();
 
     protected void RecomputeCurrentResourceKinds()
     {
@@ -2259,18 +2250,23 @@ public abstract class CharacterBase : EntityBase, ICharacter
         // If multiple identical abilities, keep only one with lowest level
         foreach (IAbilityUsage abilityUsage in abilities)
         {
-            var (_, abilityLearned) = GetAbilityLearnedInfo(abilityUsage.Name);
-            if (abilityLearned != null)
-            {
-                //Logger.LogDebug("Merging KnownAbility with AbilityUsage for {0} Ability {1}", DebugName, abilityUsage.Ability.Name);
-                abilityLearned.Update(Math.Min(abilityUsage.Level, abilityLearned.Level), Math.Min(abilityUsage.Rating, abilityLearned.Rating), Math.Min(abilityUsage.CostAmount, abilityLearned.CostAmount), Math.Max(abilityUsage.MinLearned, abilityLearned.Learned));
-                // TODO: what should be we if multiple resource kind or operator ?
-            }
-            else
-            {
-                Logger.LogDebug("Adding AbilityLearned from AbilityUsage for {name} Ability {abilityUsageName}", DebugName, abilityUsage.Name);
-                AddLearnedAbility(abilityUsage, naturalBorn);
-            }
+            MergeAbility(abilityUsage, naturalBorn);
+        }
+    }
+
+    protected void MergeAbility(IAbilityUsage abilityUsage, bool naturalBorn)
+    {
+        var (_, abilityLearned) = GetAbilityLearnedInfo(abilityUsage.Name);
+        if (abilityLearned != null)
+        {
+            //Logger.LogDebug("Merging KnownAbility with AbilityUsage for {0} Ability {1}", DebugName, abilityUsage.Ability.Name);
+            abilityLearned.Update(Math.Min(abilityUsage.Level, abilityLearned.Level), Math.Min(abilityUsage.Rating, abilityLearned.Rating), Math.Min(abilityUsage.CostAmount, abilityLearned.CostAmount), Math.Max(abilityUsage.MinLearned, abilityLearned.Learned));
+            // TODO: what should be we if multiple resource kind or operator ?
+        }
+        else
+        {
+            Logger.LogDebug("Adding AbilityLearned from AbilityUsage for {name} Ability {abilityUsageName}", DebugName, abilityUsage.Name);
+            AddLearnedAbility(abilityUsage, naturalBorn);
         }
     }
 

--- a/Mud.Server/Character/NonPlayableCharacter/NonPlayableCharacter.cs
+++ b/Mud.Server/Character/NonPlayableCharacter/NonPlayableCharacter.cs
@@ -730,6 +730,12 @@ public class NonPlayableCharacter : CharacterBase, INonPlayableCharacter
         // NOP
     }
 
+    protected override void RecomputeKnownAbilities()
+    {
+        if (Class != null)
+            MergeAbilities(Class.AvailableAbilities, false);
+    }
+
     #endregion
 
     protected bool UseSkill(string skillName, params ICommandParameter[] parameters)

--- a/Mud.Server/Server/Server.cs
+++ b/Mud.Server/Server/Server.cs
@@ -219,6 +219,7 @@ public class Server : IServer, IWorld, IPlayerManager, IServerAdminCommand, ISer
     {
         Logger.LogInformation("#WeaponEffects: {count}", WeaponEffectManager.Count);
         Logger.LogInformation("#Abilities: {count}", AbilityManager.Abilities.Count());
+        Logger.LogInformation("#Weapons: {count}", AbilityManager.Abilities.Count(x => x.Type == AbilityTypes.Weapon));
         Logger.LogInformation("#Passives: {count}", AbilityManager.Abilities.Count(x => x.Type == AbilityTypes.Passive));
         Logger.LogInformation("#Spells: {count}", AbilityManager.Abilities.Count(x => x.Type == AbilityTypes.Spell));
         Logger.LogInformation("#Skills: {count}", AbilityManager.Abilities.Count(x => x.Type == AbilityTypes.Skill));

--- a/TODO.txt
+++ b/TODO.txt
@@ -1,188 +1,33 @@
 INGOING
 DONE
-    GetValues removed from EnumHelpers
-    MaxAttributes capping refactored
-    issue fixed in armor value in damage function
-    ! cannot be used with deleteavatar
-    once any other command than deleteavatar is used, reset deleteavatar 1st try
-    logger removed from AbilityInfo
+    ability group definition
+    classes expose ability group usage: group name + cost
+    ability group manager exposes ability group info: group name + help + abilities infos (similar to ability manager) + included groups
+    ability group in avatar creation
+    don't merge anymore abilities from class with learned abilities, use ability group instead
+    characters exposes learned ability group : group name + cost
+        --> quite similar to learned abilities
+
 ==========
 == TODO ==
 ==========
 
-issue with learned ability when gaining level
-    how could we differentiate an ability learned but not yet practiced from an ability not yet learned
+add 'unique' admin command to display entries in UniquenessManager
 
-oaffects/iaffects display affects from equipments
+IsAll in command parser has a side effect
+    -> parameter.value is empty and if the command uses StartWith it will match the first item in the list
+
+once a mob has been bashed it cannot be bashed again because it's position will not be set to stand
+    -> did we miss something in XXXUpdate in Server ?
+
+customization
+ability group
+    gain command can also gain group of abilities (we should display which abilities are already known when displaying group)
+    help about ability group
+
 finish score
 
-skill/spell/passive groups
-gain command can also gain group of abilities (we should display which abilities are already known when displaying group)
-alignment/groups/... selection during avatar creation
-
-// every player: rom basics
-// every class: 'class' basics
-// default if no customization: 'class' default
-
-{
-    // name, cost:{mage, cleric, thief, warrior}
-    // group/spell list
-    {
-	"rom basics",		{ 0, 0, 0, 0 },
-	{ "scrolls", "staves", "wands", "recall" }
-    },
-
-    {
-	"mage basics",		{ 0, -1, -1, -1 },
-	{ "dagger" }
-    },
-
-    {
-	"cleric basics",	{ -1, 0, -1, -1 },
-	{ "mace" }
-    },
-   
-    {
-	"thief basics",		{ -1, -1, 0, -1 },
-	{ "dagger", "steal" }
-    },
-
-    {
-	"warrior basics",	{ -1, -1, -1, 0 },
-	{ "sword", "second attack" }
-    },
-
-    {
-	"mage default",		{ 40, -1, -1, -1 },
-	{ "lore", "beguiling", "combat", "detection", "enhancement", "illusion",
-	  "maladictions", "protective", "transportation", "weather" }
-    },
-
-    {
-	"cleric default",	{ -1, 40, -1, -1 },
-	{ "flail", "attack", "creation", "curative",  "benedictions", 
-	  "detection", "healing", "maladictions", "protective", "shield block", 
-	  "transportation", "weather" }
-    },
- 
-    {
-	"thief default",	{ -1, -1, 40, -1 },
-	{ "mace", "sword", "backstab", "disarm", "dodge", "second attack",
-	  "trip", "hide", "peek", "pick lock", "sneak" }
-    },
-
-    {
-	"warrior default",	{ -1, -1, -1, 40 },
-	{ "weaponsmaster", "shield block", "bash", "disarm", "enhanced damage", 
-	  "parry", "rescue", "third attack" }
-    },
-
-    {
-	"weaponsmaster",	{ 40, 40, 40, 20 },
-	{ "axe", "dagger", "flail", "mace", "polearm", "spear", "sword","whip" }
-    },
-
-    {
-	"attack",		{ -1, 5, -1, 8 },
-	{ "demonfire", "dispel evil", "dispel good", "earthquake", 
-	  "flamestrike", "heat metal", "ray of truth" }
-    },
-
-    {
-	"beguiling",		{ 4, -1, 6, -1 },
-	{ "calm", "charm person", "sleep" }
-    },
-
-    {
-	"benedictions",		{ -1, 4, -1, 8 },
-	{ "bless", "calm", "frenzy", "holy word", "remove curse" }
-    },
-
-    {
-	"combat",		{ 6, -1, 10, 9 },
-	{ "acid blast", "burning hands", "chain lightning", "chill touch",
-	  "colour spray", "fireball", "lightning bolt", "magic missile",
-	  "shocking grasp"  }
-    },
-
-    {
-	"creation",		{ 4, 4, 8, 8 },
-	{ "continual light", "create food", "create spring", "create water",
-	  "create rose", "floating disc" }
-    },
-
-    {
-	"curative",		{ -1, 4, -1, 8 },
-	{ "cure blindness", "cure disease", "cure poison" }
-    }, 
-
-    {
-	"detection",		{ 4, 3, 6, -1 },
- 	{ "detect evil", "detect good", "detect hidden", "detect invis", 
-	  "detect magic", "detect poison", "farsight", "identify", 
-	  "know alignment", "locate object" } 
-    },
-
-    {
-	"draconian",		{ 8, -1, -1, -1 },
-	{ "acid breath", "fire breath", "frost breath", "gas breath",
-	  "lightning breath"  }
-    },
-
-    {
-	"enchantment",		{ 6, -1, -1, -1 },
-	{ "enchant armor", "enchant weapon", "fireproof", "recharge" }
-    },
-
-    { 
-	"enhancement",		{ 5, -1, 9, 9 },
-	{ "giant strength", "haste", "infravision", "refresh" }
-    },
-
-    {
-	"harmful",		{ -1, 3, -1, 6 },
-	{ "cause critical", "cause light", "cause serious", "harm" }
-    },
-
-    {   
-	"healing",		{ -1, 3, -1, 6 },
- 	{ "cure critical", "cure light", "cure serious", "heal", 
-	  "mass healing", "refresh" }
-    },
-
-    {
-	"illusion",		{ 4, -1, 7, -1 },
-	{ "invis", "mass invis", "ventriloquate" }
-    },
-  
-    {
-	"maladictions",		{ 5, 5, 9, 9 },
-	{ "blindness", "change sex", "curse", "energy drain", "plague", 
-	  "poison", "slow", "weaken" }
-    },
-
-    { 
-	"protective",		{ 4, 4, 7, 8 },
-	{ "armor", "cancellation", "dispel magic", "fireproof",
-	  "protection evil", "protection good", "sanctuary", "shield", 
-	  "stone skin" }
-    },
-
-    {
-	"transportation",	{ 4, 4, 8, 9 },
-	{ "fly", "gate", "nexus", "pass door", "portal", "summon", "teleport", 
-	  "word of recall" }
-    },
-   
-    {
-	"weather",		{ 4, 4, 8, 8 },
-	{ "call lightning", "control weather", "faerie fire", "faerie fog",
-	  "lightning bolt" }
-    }
-}
-
-
-SkillBase,PassiveBase: we should find another way to retrive ability info than using new(GetType()) (using AbilityManager ?)
+SkillBase,PassiveBase: we should find another way to retrieve ability info than using new(GetType()) (using AbilityManager ?)
 
 check antievil/antigood/... zap (see handler.c:1586)
 
@@ -193,7 +38,7 @@ spec_mayor
 
 item owner -> to be used in CanLoot
 
-Poison/Plague/... should not specify character as source
+Poison/Plague/... should not specify character for damage source
     new Damage function without a source with additional message when dying (see update_affect.C:103)
 
 passives could be shared instead of transient


### PR DESCRIPTION
close #136 
    ability group definition
    classes expose ability group usage: group name + cost
    ability group manager exposes ability group info: group name + help + abilities infos (similar to ability manager) + included groups
    ability group in avatar creation
    don't merge anymore abilities from class with learned abilities, use ability group instead
    characters exposes learned ability group : group name + cost
        --> quite similar to learned abilities