### PR TITLE
#221  Add new game action for skill and assign guards there

### DIFF
--- a/Mud.Server.Ability/Skill/FightingSkillBase.cs
+++ b/Mud.Server.Ability/Skill/FightingSkillBase.cs
@@ -7,8 +7,8 @@ namespace Mud.Server.Ability.Skill;
 
 public abstract class FightingSkillBase : SkillBase
 {
-    protected FightingSkillBase(ILogger<FightingSkillBase> logger, IRandomManager randomManager, IAbilityManager abilityManager)
-        : base(logger, randomManager, abilityManager)
+    protected FightingSkillBase(ILogger<FightingSkillBase> logger, IRandomManager randomManager)
+        : base(logger, randomManager)
     {
     }
 

--- a/Mud.Server.Ability/Skill/ItemCastSpellSkillBase.cs
+++ b/Mud.Server.Ability/Skill/ItemCastSpellSkillBase.cs
@@ -16,11 +16,14 @@ public abstract class ItemCastSpellSkillBase<TItem> : SkillBase
     where TItem: IItem
 {
     protected IItemManager ItemManager { get; }
+    protected IAbilityManager AbilityManager { get; }
 
     protected ItemCastSpellSkillBase(ILogger<ItemCastSpellSkillBase<TItem>> logger, IRandomManager randomManager, IAbilityManager abilityManager, IItemManager itemManager)
-        : base(logger, randomManager, abilityManager)
+        : base(logger, randomManager)
     {
         ItemManager = itemManager;
+        AbilityManager = abilityManager;
+
         SpellInstances = [];
     }
 

--- a/Mud.Server.Ability/Skill/ItemInventorySkillBase.cs
+++ b/Mud.Server.Ability/Skill/ItemInventorySkillBase.cs
@@ -8,8 +8,8 @@ namespace Mud.Server.Ability.Skill;
 
 public abstract class ItemInventorySkillBase : SkillBase
 {
-    protected ItemInventorySkillBase(ILogger<ItemInventorySkillBase> logger, IRandomManager randomManager, IAbilityManager abilityManager)
-        : base(logger, randomManager, abilityManager)
+    protected ItemInventorySkillBase(ILogger<ItemInventorySkillBase> logger, IRandomManager randomManager)
+        : base(logger, randomManager)
     {
     }
 

--- a/Mud.Server.Ability/Skill/NoTargetSkillBase.cs
+++ b/Mud.Server.Ability/Skill/NoTargetSkillBase.cs
@@ -6,8 +6,8 @@ namespace Mud.Server.Ability.Skill;
 
 public abstract class NoTargetSkillBase : SkillBase
 {
-    protected NoTargetSkillBase(ILogger<NoTargetSkillBase> logger, IRandomManager randomManager, IAbilityManager abilityManager) 
-        : base(logger, randomManager, abilityManager)
+    protected NoTargetSkillBase(ILogger<NoTargetSkillBase> logger, IRandomManager randomManager) 
+        : base(logger, randomManager)
     {
     }
 

--- a/Mud.Server.Ability/Skill/OffensiveSkillBase.cs
+++ b/Mud.Server.Ability/Skill/OffensiveSkillBase.cs
@@ -8,8 +8,8 @@ namespace Mud.Server.Ability.Skill;
 
 public abstract class OffensiveSkillBase : SkillBase
 {
-    protected OffensiveSkillBase(ILogger<OffensiveSkillBase> logger, IRandomManager randomManager, IAbilityManager abilityManager)
-        : base(logger, randomManager, abilityManager)
+    protected OffensiveSkillBase(ILogger<OffensiveSkillBase> logger, IRandomManager randomManager)
+        : base(logger, randomManager)
     {
     }
     protected ICharacter Victim { get; set; } = default!;

--- a/Mud.Server.GameAction/SkillGameAction.cs
+++ b/Mud.Server.GameAction/SkillGameAction.cs
@@ -1,0 +1,8 @@
+﻿using Mud.Server.Interfaces.Character;
+using Mud.Server.Interfaces.GameAction;
+
+namespace Mud.Server.GameAction;
+
+public abstract class SkillGameAction : CharacterGameActionBase<ICharacter, ISkillGameActionInfo>
+{
+}

--- a/Mud.Server.GameAction/SkillGameActionInfo.cs
+++ b/Mud.Server.GameAction/SkillGameActionInfo.cs
@@ -1,0 +1,17 @@
+﻿using Mud.Server.Common.Attributes;
+using Mud.Server.Interfaces.Ability;
+using Mud.Server.Interfaces.GameAction;
+using Mud.Server.Interfaces.Guards;
+
+namespace Mud.Server.GameAction;
+
+public class SkillGameActionInfo : CharacterGameActionInfo, ISkillGameActionInfo
+{
+    public IAbilityDefinition AbilityDefinition { get; }
+
+    public SkillGameActionInfo(Type commandExecutionType, CharacterCommandAttribute characterCommandAttribute, SyntaxAttribute syntaxAttribute, IEnumerable<AliasAttribute> aliasAttributes, HelpAttribute? helpAttribute, IAbilityDefinition abilityDefinition, IEnumerable<ICharacterGuard> guards)
+        : base(commandExecutionType, characterCommandAttribute, syntaxAttribute, aliasAttributes, helpAttribute, guards)
+    {
+        AbilityDefinition = abilityDefinition;
+    }
+}

--- a/Mud.Server.Interfaces/GameAction/ISkillGameActionInfo.cs
+++ b/Mud.Server.Interfaces/GameAction/ISkillGameActionInfo.cs
@@ -1,0 +1,8 @@
+﻿using Mud.Server.Interfaces.Ability;
+
+namespace Mud.Server.Interfaces.GameAction;
+
+public interface ISkillGameActionInfo : ICharacterGameActionInfo
+{
+    IAbilityDefinition AbilityDefinition { get; }
+}

--- a/Mud.Server.POC/Skills/BearForm.cs
+++ b/Mud.Server.POC/Skills/BearForm.cs
@@ -7,7 +7,6 @@ using Mud.Server.Common.Attributes;
 using Mud.Server.Domain;
 using Mud.Server.Flags;
 using Mud.Server.GameAction;
-using Mud.Server.Interfaces.Ability;
 using Mud.Server.Interfaces.Aura;
 using Mud.Server.Interfaces.Character;
 using Mud.Server.Random;
@@ -24,8 +23,8 @@ public class BearForm : NoTargetSkillBase
 
     private IAuraManager AuraManager { get; }
 
-    public BearForm(ILogger<BearForm> logger, IRandomManager randomManager, IAbilityManager abilityManager, IAuraManager auraManager)
-        : base(logger, randomManager, abilityManager)
+    public BearForm(ILogger<BearForm> logger, IRandomManager randomManager, IAuraManager auraManager)
+        : base(logger, randomManager)
     {
         AuraManager = auraManager;
     }

--- a/Mud.Server.POC/Skills/CatForm.cs
+++ b/Mud.Server.POC/Skills/CatForm.cs
@@ -7,7 +7,6 @@ using Mud.Server.Common.Attributes;
 using Mud.Server.Domain;
 using Mud.Server.Flags;
 using Mud.Server.GameAction;
-using Mud.Server.Interfaces.Ability;
 using Mud.Server.Interfaces.Aura;
 using Mud.Server.Interfaces.Character;
 using Mud.Server.Random;
@@ -24,8 +23,8 @@ public class CatForm : NoTargetSkillBase
 
     private IAuraManager AuraManager { get; }
 
-    public CatForm(ILogger<CatForm> logger, IRandomManager randomManager, IAbilityManager abilityManager, IAuraManager auraManager)
-        : base(logger, randomManager, abilityManager)
+    public CatForm(ILogger<CatForm> logger, IRandomManager randomManager, IAuraManager auraManager)
+        : base(logger, randomManager)
     {
         AuraManager = auraManager;
     }

--- a/Mud.Server.POC/Skills/Claw.cs
+++ b/Mud.Server.POC/Skills/Claw.cs
@@ -6,7 +6,6 @@ using Mud.Server.Common.Attributes;
 using Mud.Server.Domain;
 using Mud.Server.GameAction;
 using Mud.Server.Guards.Attributes;
-using Mud.Server.Interfaces.Ability;
 using Mud.Server.Random;
 
 namespace Mud.Server.POC.Skills;
@@ -20,8 +19,8 @@ public class Claw : OffensiveSkillBase
 {
     private const string SkillName = "Claw";
 
-    public Claw(ILogger<Claw> logger, IRandomManager randomManager, IAbilityManager abilityManager)
-        : base(logger, randomManager, abilityManager)
+    public Claw(ILogger<Claw> logger, IRandomManager randomManager)
+        : base(logger, randomManager)
     {
     }
 

--- a/Mud.Server.POC/Skills/DemoralizingRoar.cs
+++ b/Mud.Server.POC/Skills/DemoralizingRoar.cs
@@ -7,7 +7,6 @@ using Mud.Server.Common.Attributes;
 using Mud.Server.Domain;
 using Mud.Server.GameAction;
 using Mud.Server.Guards.Attributes;
-using Mud.Server.Interfaces.Ability;
 using Mud.Server.Interfaces.Aura;
 using Mud.Server.Interfaces.Character;
 using Mud.Server.Random;
@@ -25,8 +24,8 @@ public class DemoralizingRoar : OffensiveSkillBase
 
     private IAuraManager AuraManager { get; }
 
-    public DemoralizingRoar(ILogger<DemoralizingRoar> logger, IRandomManager randomManager, IAbilityManager abilityManager, IAuraManager auraManager)
-        : base(logger, randomManager, abilityManager)
+    public DemoralizingRoar(ILogger<DemoralizingRoar> logger, IRandomManager randomManager, IAuraManager auraManager)
+        : base(logger, randomManager)
     {
         AuraManager = auraManager;
     }

--- a/Mud.Server.POC/Skills/FerociousBite.cs
+++ b/Mud.Server.POC/Skills/FerociousBite.cs
@@ -6,7 +6,6 @@ using Mud.Server.Common.Attributes;
 using Mud.Server.Domain;
 using Mud.Server.GameAction;
 using Mud.Server.Guards.Attributes;
-using Mud.Server.Interfaces.Ability;
 using Mud.Server.Random;
 
 namespace Mud.Server.POC.Skills;
@@ -25,8 +24,8 @@ public class FerociousBite : OffensiveSkillBase
 {
     private const string SkillName = "Ferocious Bite";
 
-    public FerociousBite(ILogger<FerociousBite> logger, IRandomManager randomManager, IAbilityManager abilityManager)
-        : base(logger, randomManager, abilityManager)
+    public FerociousBite(ILogger<FerociousBite> logger, IRandomManager randomManager)
+        : base(logger, randomManager)
     {
     }
 

--- a/Mud.Server.POC/Skills/Maul.cs
+++ b/Mud.Server.POC/Skills/Maul.cs
@@ -6,7 +6,6 @@ using Mud.Server.Common.Attributes;
 using Mud.Server.Domain;
 using Mud.Server.GameAction;
 using Mud.Server.Guards.Attributes;
-using Mud.Server.Interfaces.Ability;
 using Mud.Server.Interfaces.Aura;
 using Mud.Server.POC.Affects;
 using Mud.Server.Random;
@@ -24,8 +23,8 @@ public class Maul : OffensiveSkillBase
 
     private IAuraManager AuraManager { get; }
 
-    public Maul(ILogger<Maul> logger, IRandomManager randomManager, IAbilityManager abilityManager, IAuraManager auraManager)
-        : base(logger, randomManager, abilityManager)
+    public Maul(ILogger<Maul> logger, IRandomManager randomManager, IAuraManager auraManager)
+        : base(logger, randomManager)
     {
         AuraManager = auraManager;
     }

--- a/Mud.Server.POC/Skills/Rake.cs
+++ b/Mud.Server.POC/Skills/Rake.cs
@@ -6,7 +6,6 @@ using Mud.Server.Common.Attributes;
 using Mud.Server.Domain;
 using Mud.Server.GameAction;
 using Mud.Server.Guards.Attributes;
-using Mud.Server.Interfaces.Ability;
 using Mud.Server.Interfaces.Aura;
 using Mud.Server.POC.Affects;
 using Mud.Server.Random;
@@ -24,8 +23,8 @@ public class Rake : OffensiveSkillBase
 
     private IAuraManager AuraManager { get; }
 
-    public Rake(ILogger<Rake> logger, IRandomManager randomManager, IAbilityManager abilityManager, IAuraManager auraManager)
-        : base(logger, randomManager, abilityManager)
+    public Rake(ILogger<Rake> logger, IRandomManager randomManager, IAuraManager auraManager)
+        : base(logger, randomManager)
     {
         AuraManager = auraManager;
     }

--- a/Mud.Server.POC/Skills/Swipe.cs
+++ b/Mud.Server.POC/Skills/Swipe.cs
@@ -8,7 +8,6 @@ using Mud.Server.Common.Extensions;
 using Mud.Server.Domain;
 using Mud.Server.GameAction;
 using Mud.Server.Guards.Attributes;
-using Mud.Server.Interfaces.Ability;
 using Mud.Server.Interfaces.Character;
 using Mud.Server.Random;
 
@@ -23,8 +22,8 @@ public class Swipe : FightingSkillBase
 {
     private const string SkillName = "Swipe";
 
-    public Swipe(ILogger<Swipe> logger, IRandomManager randomManager, IAbilityManager abilityManager)
-        : base(logger, randomManager, abilityManager)
+    public Swipe(ILogger<Swipe> logger, IRandomManager randomManager)
+        : base(logger, randomManager)
     {
     }
 

--- a/Mud.Server.Rom24.Tests/Abilities/AbilityTestBase.cs
+++ b/Mud.Server.Rom24.Tests/Abilities/AbilityTestBase.cs
@@ -3,6 +3,7 @@ using Moq;
 using Mud.Common;
 using Mud.Domain;
 using Mud.Server.Ability;
+using Mud.Server.Common.Attributes;
 using Mud.Server.GameAction;
 using Mud.Server.Interfaces.Ability;
 using Mud.Server.Interfaces.Actor;
@@ -60,7 +61,13 @@ public abstract class AbilityTestBase
             case CharacterCommandAttribute characterCommandAttribute:
                 {
                     var characterGuards = guardGenerator.GenerateCharacterGuards(type);
-                    gameActionInfo = new CharacterGameActionInfo(type, characterCommandAttribute, syntaxAttribute, aliasAttributes, null, characterGuards);
+                    if (type.IsAssignableTo(typeof(ISkill)))
+                    {
+                        var skillDefinition = new AbilityDefinition(type, characterGuards);
+                        gameActionInfo = new SkillGameActionInfo(type, characterCommandAttribute, syntaxAttribute, aliasAttributes, null, skillDefinition, characterGuards);
+                    }
+                    else
+                        gameActionInfo = new CharacterGameActionInfo(type, characterCommandAttribute, syntaxAttribute, aliasAttributes, null, characterGuards);
                     break;
                 }
             case AdminCommandAttribute adminCommandAttribute:

--- a/Mud.Server.Rom24.Tests/Abilities/BerserkTests.cs
+++ b/Mud.Server.Rom24.Tests/Abilities/BerserkTests.cs
@@ -5,7 +5,6 @@ using Mud.Domain;
 using Mud.Server.Ability;
 using Mud.Server.Ability.Skill;
 using Mud.Server.Flags;
-using Mud.Server.Interfaces.Ability;
 using Mud.Server.Interfaces.Aura;
 using Mud.Server.Interfaces.Character;
 using Mud.Server.Interfaces.Room;
@@ -21,7 +20,6 @@ public class BerserkTests : AbilityTestBase
     public void PcNotKnown()
     {
         Mock<IRandomManager> randomManagerMock = new();
-        Mock<IAbilityManager> abilityManagerMock = new();
         Mock<IAuraManager> auraManagerMock = new();
 
         Mock<IPlayableCharacter> userMock = new();
@@ -29,7 +27,7 @@ public class BerserkTests : AbilityTestBase
         userMock.SetupGet(x => x.Room).Returns(roomMock.Object);
         roomMock.SetupGet(x => x.People).Returns(userMock.Object.Yield());
 
-        var skill = new Berserk(new Mock<ILogger<Berserk>>().Object, randomManagerMock.Object, abilityManagerMock.Object, auraManagerMock.Object);
+        var skill = new Berserk(new Mock<ILogger<Berserk>>().Object, randomManagerMock.Object, auraManagerMock.Object);
         var actionInput = BuildActionInput<Berserk>(userMock.Object, "berserk");
         var skillActionInput = new SkillActionInput(actionInput, new AbilityDefinition(skill.GetType(), []), userMock.Object);
 
@@ -42,7 +40,6 @@ public class BerserkTests : AbilityTestBase
     public void NpcNotKnownNoOffensiveFlags()
     {
         Mock<IRandomManager> randomManagerMock = new();
-        Mock<IAbilityManager> abilityManagerMock = new();
         Mock<IAuraManager> auraManagerMock = new();
 
         Mock<INonPlayableCharacter> userMock = new();
@@ -50,7 +47,7 @@ public class BerserkTests : AbilityTestBase
         userMock.SetupGet(x => x.Room).Returns(roomMock.Object);
         roomMock.SetupGet(x => x.People).Returns(userMock.Object.Yield());
 
-        var skill = new Berserk(new Mock<ILogger<Berserk>>().Object, randomManagerMock.Object, abilityManagerMock.Object, auraManagerMock.Object);
+        var skill = new Berserk(new Mock<ILogger<Berserk>>().Object, randomManagerMock.Object, auraManagerMock.Object);
         var actionInput = BuildActionInput<Berserk>(userMock.Object, "berserk");
         var skillActionInput = new SkillActionInput(actionInput, new AbilityDefinition(skill.GetType(), []), userMock.Object);
 
@@ -63,7 +60,6 @@ public class BerserkTests : AbilityTestBase
     public void NpcNotKnownBerserkOffensiveFlags()
     {
         Mock<IRandomManager> randomManagerMock = new();
-        Mock<IAbilityManager> abilityManagerMock = new();
         Mock<IAuraManager> auraManagerMock = new();
 
         Mock<INonPlayableCharacter> userMock = new();
@@ -75,7 +71,7 @@ public class BerserkTests : AbilityTestBase
         userMock.SetupGet(x => x[It.IsAny<ResourceKinds>()]).Returns(1000); // enough mana
         roomMock.SetupGet(x => x.People).Returns(userMock.Object.Yield());
 
-        var skill = new Berserk(new Mock<ILogger<Berserk>>().Object, randomManagerMock.Object, abilityManagerMock.Object, auraManagerMock.Object);
+        var skill = new Berserk(new Mock<ILogger<Berserk>>().Object, randomManagerMock.Object, auraManagerMock.Object);
         var actionInput = BuildActionInput<Berserk>(userMock.Object, "berserk");
         var skillActionInput = new SkillActionInput(actionInput, new AbilityDefinition(skill.GetType(), []), userMock.Object);
 
@@ -88,7 +84,6 @@ public class BerserkTests : AbilityTestBase
     public void HasBerserkFlags()
     {
         Mock<IRandomManager> randomManagerMock = new();
-        Mock<IAbilityManager> abilityManagerMock = new();
         Mock<IAuraManager> auraManagerMock = new();
 
         Mock<IPlayableCharacter> userMock = new();
@@ -101,7 +96,7 @@ public class BerserkTests : AbilityTestBase
         userMock.SetupGet(x => x[It.IsAny<ResourceKinds>()]).Returns(1000); // enough mana
         roomMock.SetupGet(x => x.People).Returns(userMock.Object.Yield());
 
-        var skill = new Berserk(new Mock<ILogger<Berserk>>().Object, randomManagerMock.Object, abilityManagerMock.Object, auraManagerMock.Object);
+        var skill = new Berserk(new Mock<ILogger<Berserk>>().Object, randomManagerMock.Object, auraManagerMock.Object);
         var actionInput = BuildActionInput<Berserk>(userMock.Object, "berserk");
         var skillActionInput = new SkillActionInput(actionInput, new AbilityDefinition(skill.GetType(), []), userMock.Object);
 
@@ -114,7 +109,6 @@ public class BerserkTests : AbilityTestBase
     public void AffectedByBerserk()
     {
         Mock<IRandomManager> randomManagerMock = new();
-        Mock<IAbilityManager> abilityManagerMock = new();
         Mock<IAuraManager> auraManagerMock = new();
 
         Mock<IPlayableCharacter> userMock = new();
@@ -127,7 +121,7 @@ public class BerserkTests : AbilityTestBase
         userMock.SetupGet(x => x[It.IsAny<ResourceKinds>()]).Returns(1000); // enough mana
         roomMock.SetupGet(x => x.People).Returns(userMock.Object.Yield());
 
-        var skill = new Berserk(new Mock<ILogger<Berserk>>().Object, randomManagerMock.Object, abilityManagerMock.Object, auraManagerMock.Object);
+        var skill = new Berserk(new Mock<ILogger<Berserk>>().Object, randomManagerMock.Object, auraManagerMock.Object);
         var actionInput = BuildActionInput<Berserk>(userMock.Object, "berserk");
         var skillActionInput = new SkillActionInput(actionInput, new AbilityDefinition(skill.GetType(), []), userMock.Object);
 
@@ -140,7 +134,6 @@ public class BerserkTests : AbilityTestBase
     public void HasCalmFlag()
     {
         Mock<IRandomManager> randomManagerMock = new();
-        Mock<IAbilityManager> abilityManagerMock = new();
         Mock<IAuraManager> auraManagerMock = new();
 
         Mock<IPlayableCharacter> userMock = new();
@@ -153,7 +146,7 @@ public class BerserkTests : AbilityTestBase
         userMock.SetupGet(x => x[It.IsAny<ResourceKinds>()]).Returns(1000); // enough mana
         roomMock.SetupGet(x => x.People).Returns(userMock.Object.Yield());
 
-        var skill = new Berserk(new Mock<ILogger<Berserk>>().Object, randomManagerMock.Object, abilityManagerMock.Object, auraManagerMock.Object);
+        var skill = new Berserk(new Mock<ILogger<Berserk>>().Object, randomManagerMock.Object, auraManagerMock.Object);
         var actionInput = BuildActionInput<Berserk>(userMock.Object, "berserk");
         var skillActionInput = new SkillActionInput(actionInput, new AbilityDefinition(skill.GetType(), []), userMock.Object);
 
@@ -166,7 +159,6 @@ public class BerserkTests : AbilityTestBase
     public void NoMana()
     {
         Mock<IRandomManager> randomManagerMock = new();
-        Mock<IAbilityManager> abilityManagerMock = new();
         Mock<IAuraManager> auraManagerMock = new();
 
         Mock<IPlayableCharacter> userMock = new();
@@ -176,7 +168,7 @@ public class BerserkTests : AbilityTestBase
         userMock.Setup(x => x.GetAbilityLearnedAndPercentage(It.IsAny<string>())).Returns<string>(abilityName => (100, BuildAbilityLearned(abilityName)));
         roomMock.SetupGet(x => x.People).Returns(userMock.Object.Yield());
 
-        var skill = new Berserk(new Mock<ILogger<Berserk>>().Object, randomManagerMock.Object, abilityManagerMock.Object, auraManagerMock.Object);
+        var skill = new Berserk(new Mock<ILogger<Berserk>>().Object, randomManagerMock.Object, auraManagerMock.Object);
         var actionInput = BuildActionInput<Berserk>(userMock.Object, "berserk");
         var skillActionInput = new SkillActionInput(actionInput, new AbilityDefinition(skill.GetType(), []), userMock.Object);
 
@@ -190,7 +182,6 @@ public class BerserkTests : AbilityTestBase
     {
         Mock<IRandomManager> randomManagerMock = new();
         randomManagerMock.Setup(x => x.Chance(It.IsAny<int>())).Returns<int>(_ => false);
-        Mock<IAbilityManager> abilityManagerMock = new();
         Mock<IAuraManager> auraManagerMock = new();
 
         Mock<IPlayableCharacter> userMock = new();
@@ -203,7 +194,7 @@ public class BerserkTests : AbilityTestBase
         userMock.SetupGet(x => x.MaxHitPoints).Returns(1000);
         roomMock.SetupGet(x => x.People).Returns(userMock.Object.Yield());
 
-        var skill = new Berserk(new Mock<ILogger<Berserk>>().Object, randomManagerMock.Object, abilityManagerMock.Object, auraManagerMock.Object);
+        var skill = new Berserk(new Mock<ILogger<Berserk>>().Object, randomManagerMock.Object, auraManagerMock.Object);
         var actionInput = BuildActionInput<Berserk>(userMock.Object, "berserk");
         var skillActionInput = new SkillActionInput(actionInput, new AbilityDefinition(skill.GetType(), []), userMock.Object);
 
@@ -219,7 +210,6 @@ public class BerserkTests : AbilityTestBase
     {
         Mock<IRandomManager> randomManagerMock = new();
         randomManagerMock.Setup(x => x.Chance(It.IsAny<int>())).Returns<int>(_ => true);
-        Mock<IAbilityManager> abilityManagerMock = new();
         Mock<IAuraManager> auraManagerMock = new();
 
         Mock<IPlayableCharacter> userMock = new();
@@ -232,7 +222,7 @@ public class BerserkTests : AbilityTestBase
         userMock.SetupGet(x => x.MaxHitPoints).Returns(1000);
         roomMock.SetupGet(x => x.People).Returns(userMock.Object.Yield());
 
-        var skill = new Berserk(new Mock<ILogger<Berserk>>().Object, randomManagerMock.Object, abilityManagerMock.Object, auraManagerMock.Object);
+        var skill = new Berserk(new Mock<ILogger<Berserk>>().Object, randomManagerMock.Object, auraManagerMock.Object);
         var actionInput = BuildActionInput<Berserk>(userMock.Object, "berserk");
         var skillActionInput = new SkillActionInput(actionInput, new AbilityDefinition(skill.GetType(), []), userMock.Object);
 
@@ -246,7 +236,6 @@ public class BerserkTests : AbilityTestBase
     {
         Mock<IRandomManager> randomManagerMock = new();
         randomManagerMock.Setup(x => x.Chance(It.IsAny<int>())).Returns<int>(_ => true);
-        Mock<IAbilityManager> abilityManagerMock = new();
         Mock<IAuraManager> auraManagerMock = new();
 
         Mock<IPlayableCharacter> userMock = new();
@@ -259,7 +248,7 @@ public class BerserkTests : AbilityTestBase
         userMock.SetupGet(x => x.MaxHitPoints).Returns(1000);
         roomMock.SetupGet(x => x.People).Returns(userMock.Object.Yield());
 
-        var skill = new Berserk(new Mock<ILogger<Berserk>>().Object, randomManagerMock.Object, abilityManagerMock.Object, auraManagerMock.Object);
+        var skill = new Berserk(new Mock<ILogger<Berserk>>().Object, randomManagerMock.Object, auraManagerMock.Object);
         var actionInput = BuildActionInput<Berserk>(userMock.Object, "berserk");
         var skillActionInput = new SkillActionInput(actionInput, new AbilityDefinition(skill.GetType(), []), userMock.Object);
 
@@ -275,8 +264,6 @@ public class BerserkTests : AbilityTestBase
     {
         Mock<IRandomManager> randomManagerMock = new();
         randomManagerMock.Setup(x => x.Chance(It.IsAny<int>())).Returns<int>(_ => true);
-        Mock<IAbilityManager> abilityManagerMock = new();
-        abilityManagerMock.SetupGet(x => x[It.IsAny<Type>()]).Returns(new AbilityDefinition(typeof(Berserk), []));
         Mock<IAuraManager> auraManagerMock = new();
 
         Mock<IPlayableCharacter> userMock = new();
@@ -289,11 +276,8 @@ public class BerserkTests : AbilityTestBase
         userMock.SetupGet(x => x.MaxHitPoints).Returns(1000);
         roomMock.SetupGet(x => x.People).Returns(userMock.Object.Yield());
 
-        //_guardGeneratorMock.Setup(x => x.GenerateCharacterGuards(It.IsAny<Type>()))
-        //    .Returns([]);
-
         var actionInput = BuildActionInput<Berserk>(userMock.Object, "berserk");
-        var skill = new Berserk(new Mock<ILogger<Berserk>>().Object, randomManagerMock.Object, abilityManagerMock.Object, auraManagerMock.Object);
+        var skill = new Berserk(new Mock<ILogger<Berserk>>().Object, randomManagerMock.Object, auraManagerMock.Object);
         var result = skill.Guards(actionInput);
         skill.Execute(actionInput);
 

--- a/Mud.Server.Rom24.Tests/Affects/ProtectionGoodDamageModifierAffectTests.cs
+++ b/Mud.Server.Rom24.Tests/Affects/ProtectionGoodDamageModifierAffectTests.cs
@@ -15,7 +15,7 @@ public class ProtectionGoodDamageModifierAffectTests
         chMock.SetupGet(x => x.IsGood).Returns(false);
 
         var affect = new ProtectionGoodDamageModifierAffect();
-        var modifiedDamage = affect.ModifyDamage(chMock.Object, null!, SchoolTypes.Pierce, 100);
+        var modifiedDamage = affect.ModifyDamage(chMock.Object, null!, SchoolTypes.Pierce, DamageSources.Ability, 100);
 
         Assert.AreEqual(100, modifiedDamage);
     }
@@ -27,7 +27,7 @@ public class ProtectionGoodDamageModifierAffectTests
         chMock.SetupGet(x => x.IsGood).Returns(true);
 
         var affect = new ProtectionGoodDamageModifierAffect();
-        var modifiedDamage = affect.ModifyDamage(chMock.Object, null!, SchoolTypes.Pierce, 100);
+        var modifiedDamage = affect.ModifyDamage(chMock.Object, null!, SchoolTypes.Pierce, DamageSources.Ability, 100);
 
         Assert.AreEqual(75, modifiedDamage);
     }

--- a/Mud.Server.Rom24/Skills/Backstab.cs
+++ b/Mud.Server.Rom24/Skills/Backstab.cs
@@ -28,8 +28,8 @@ public class Backstab : OffensiveSkillBase
 {
     private const string SkillName = "Backstab";
 
-    public Backstab(ILogger<Backstab> logger, IRandomManager randomManager, IAbilityManager abilityManager)
-        : base(logger, randomManager, abilityManager)
+    public Backstab(ILogger<Backstab> logger, IRandomManager randomManager)
+        : base(logger, randomManager)
     {
     }
 
@@ -48,7 +48,7 @@ public class Backstab : OffensiveSkillBase
 
         // TODO: check kill stealing
 
-        if (!(User.GetEquipment(EquipmentSlots.MainHand) is IItemWeapon))
+        if (User.GetEquipment(EquipmentSlots.MainHand) is not IItemWeapon)
             return "You need to wield a weapon to backstab.";
 
         if (Victim.CurrentHitPoints < Victim.MaxHitPoints / 3)

--- a/Mud.Server.Rom24/Skills/Bash.cs
+++ b/Mud.Server.Rom24/Skills/Bash.cs
@@ -26,8 +26,8 @@ public class Bash : OffensiveSkillBase
 {
     private const string SkillName = "Bash";
 
-    public Bash(ILogger<Bash> logger, IRandomManager randomManager, IAbilityManager abilityManager)
-        : base(logger, randomManager, abilityManager)
+    public Bash(ILogger<Bash> logger, IRandomManager randomManager)
+        : base(logger, randomManager)
     {
     }
 

--- a/Mud.Server.Rom24/Skills/Berserk.cs
+++ b/Mud.Server.Rom24/Skills/Berserk.cs
@@ -28,8 +28,8 @@ public class Berserk : NoTargetSkillBase
 
     private IAuraManager AuraManager { get; }
 
-    public Berserk(ILogger<Berserk> logger, IRandomManager randomManager, IAbilityManager abilityManager, IAuraManager auraManager) 
-        : base(logger, randomManager, abilityManager)
+    public Berserk(ILogger<Berserk> logger, IRandomManager randomManager, IAuraManager auraManager) 
+        : base(logger, randomManager)
     {
         AuraManager = auraManager;
     }

--- a/Mud.Server.Rom24/Skills/DirtKicking.cs
+++ b/Mud.Server.Rom24/Skills/DirtKicking.cs
@@ -29,8 +29,8 @@ public class DirtKicking : OffensiveSkillBase
 
     private IAuraManager AuraManager { get; }
 
-    public DirtKicking(ILogger<DirtKicking> logger, IRandomManager randomManager, IAbilityManager abilityManager, IAuraManager auraManager)
-        : base(logger, randomManager, abilityManager)
+    public DirtKicking(ILogger<DirtKicking> logger, IRandomManager randomManager, IAuraManager auraManager)
+        : base(logger, randomManager)
     {
         AuraManager = auraManager;
     }

--- a/Mud.Server.Rom24/Skills/Disarm.cs
+++ b/Mud.Server.Rom24/Skills/Disarm.cs
@@ -23,8 +23,8 @@ public class Disarm : FightingSkillBase
 {
     private const string SkillName = "Disarm";
 
-    public Disarm(ILogger<Disarm> logger, IRandomManager randomManager, IAbilityManager abilityManager)
-        : base(logger, randomManager, abilityManager)
+    public Disarm(ILogger<Disarm> logger, IRandomManager randomManager)
+        : base(logger, randomManager)
     {
     }
 

--- a/Mud.Server.Rom24/Skills/Envenom.cs
+++ b/Mud.Server.Rom24/Skills/Envenom.cs
@@ -39,8 +39,8 @@ public class Envenom : ItemInventorySkillBase
 
     private IAuraManager AuraManager { get; }
 
-    public Envenom(ILogger<Envenom> logger, IRandomManager randomManager, IAbilityManager abilityManager, IAuraManager auraManager)
-        : base(logger, randomManager, abilityManager)
+    public Envenom(ILogger<Envenom> logger, IRandomManager randomManager, IAuraManager auraManager)
+        : base(logger, randomManager)
     {
         AuraManager = auraManager;
     }

--- a/Mud.Server.Rom24/Skills/Hide.cs
+++ b/Mud.Server.Rom24/Skills/Hide.cs
@@ -4,7 +4,6 @@ using Mud.Server.Ability.Skill;
 using Mud.Server.Common.Attributes;
 using Mud.Server.Domain;
 using Mud.Server.GameAction;
-using Mud.Server.Interfaces.Ability;
 using Mud.Server.Random;
 
 namespace Mud.Server.Rom24.Skills;
@@ -23,8 +22,8 @@ public class Hide : NoTargetSkillBase
 {
     private const string SkillName = "Hide";
 
-    public Hide(ILogger<Hide> logger, IRandomManager randomManager, IAbilityManager abilityManager)
-        : base(logger, randomManager, abilityManager)
+    public Hide(ILogger<Hide> logger, IRandomManager randomManager)
+        : base(logger, randomManager)
     {
     }
 

--- a/Mud.Server.Rom24/Skills/Kick.cs
+++ b/Mud.Server.Rom24/Skills/Kick.cs
@@ -21,8 +21,8 @@ public class Kick : OffensiveSkillBase
 {
     private const string SkillName = "Kick";
 
-    public Kick(ILogger<Kick> logger, IRandomManager randomManager, IAbilityManager abilityManager) 
-        : base(logger, randomManager, abilityManager)
+    public Kick(ILogger<Kick> logger, IRandomManager randomManager) 
+        : base(logger, randomManager)
     {
     }
 
@@ -32,7 +32,8 @@ public class Kick : OffensiveSkillBase
         if (baseSetup != null)
             return baseSetup;
 
-        if (Learned == 0 || (User is INonPlayableCharacter npcSource && !npcSource.OffensiveFlags.IsSet("Kick")))
+        if (Learned == 0
+            || (User is INonPlayableCharacter npcSource && !npcSource.OffensiveFlags.IsSet("Kick")))
             return "You better leave the martial arts to fighters.";
 
         if (User.Position < Positions.Standing)

--- a/Mud.Server.Rom24/Skills/Lore.cs
+++ b/Mud.Server.Rom24/Skills/Lore.cs
@@ -7,7 +7,6 @@ using Mud.Server.Common.Attributes;
 using Mud.Server.Domain;
 using Mud.Server.GameAction;
 using Mud.Server.Interfaces;
-using Mud.Server.Interfaces.Ability;
 using Mud.Server.Interfaces.Aura;
 using Mud.Server.Interfaces.Item;
 using Mud.Server.Interfaces.Table;
@@ -34,8 +33,8 @@ public class Lore : ItemInventorySkillBase
     private ITableValues TableValues { get; }
     private IWiznet Wiznet { get; }
 
-    public Lore(ILogger<ItemInventorySkillBase> logger, IRandomManager randomManager, IAbilityManager abilityManager, ITableValues tableValues, IWiznet wiznet)
-        : base(logger, randomManager, abilityManager)
+    public Lore(ILogger<ItemInventorySkillBase> logger, IRandomManager randomManager, ITableValues tableValues, IWiznet wiznet)
+        : base(logger, randomManager)
     {
         TableValues = tableValues;
         Wiznet = wiznet;

--- a/Mud.Server.Rom24/Skills/NonPlayableCharacter/Bite.cs
+++ b/Mud.Server.Rom24/Skills/NonPlayableCharacter/Bite.cs
@@ -16,8 +16,8 @@ public class Bite : FightingSkillBase
 {
     private const string SkillName = "Bite";
 
-    public Bite(ILogger<Bite> logger, IRandomManager randomManager, IAbilityManager abilityManager)
-        : base(logger, randomManager, abilityManager)
+    public Bite(ILogger<Bite> logger, IRandomManager randomManager)
+        : base(logger, randomManager)
     {
     }
 

--- a/Mud.Server.Rom24/Skills/NonPlayableCharacter/Crush.cs
+++ b/Mud.Server.Rom24/Skills/NonPlayableCharacter/Crush.cs
@@ -19,8 +19,8 @@ public class Crush : FightingSkillBase
 
     private ITableValues TableValues { get; }
 
-    public Crush(ILogger<Crush> logger, IRandomManager randomManager, IAbilityManager abilityManager, ITableValues tableValues)
-        : base(logger, randomManager, abilityManager)
+    public Crush(ILogger<Crush> logger, IRandomManager randomManager, ITableValues tableValues)
+        : base(logger, randomManager)
     {
         TableValues = tableValues;
     }

--- a/Mud.Server.Rom24/Skills/NonPlayableCharacter/Tail.cs
+++ b/Mud.Server.Rom24/Skills/NonPlayableCharacter/Tail.cs
@@ -16,8 +16,8 @@ public class Tail : FightingSkillBase
 {
     private const string SkillName = "Tail";
 
-    public Tail(ILogger<Tail> logger, IRandomManager randomManager, IAbilityManager abilityManager)
-        : base(logger, randomManager, abilityManager)
+    public Tail(ILogger<Tail> logger, IRandomManager randomManager)
+        : base(logger, randomManager)
     {
     }
 

--- a/Mud.Server.Rom24/Skills/PickLock.cs
+++ b/Mud.Server.Rom24/Skills/PickLock.cs
@@ -31,8 +31,8 @@ public class PickLock : SkillBase
 {
     private const string SkillName = "Pick Lock";
 
-    public PickLock(ILogger<PickLock> logger, IRandomManager randomManager, IAbilityManager abilityManager)
-        : base(logger, randomManager, abilityManager)
+    public PickLock(ILogger<PickLock> logger, IRandomManager randomManager)
+        : base(logger, randomManager)
     {
     }
 

--- a/Mud.Server.Rom24/Skills/Recall.cs
+++ b/Mud.Server.Rom24/Skills/Recall.cs
@@ -32,8 +32,8 @@ public class Recall : NoTargetSkillBase
 {
     private const string SkillName = "Recall";
 
-    public Recall(ILogger<Recall> logger, IRandomManager randomManager, IAbilityManager abilityManager)
-        : base(logger, randomManager, abilityManager)
+    public Recall(ILogger<Recall> logger, IRandomManager randomManager)
+        : base(logger, randomManager)
     {
     }
 

--- a/Mud.Server.Rom24/Skills/Rescue.cs
+++ b/Mud.Server.Rom24/Skills/Rescue.cs
@@ -25,8 +25,8 @@ public class Rescue : OffensiveSkillBase
 {
     private const string SkillName = "Rescue";
 
-    public Rescue(ILogger<Rescue> logger, IRandomManager randomManager, IAbilityManager abilityManager)
-        : base(logger, randomManager, abilityManager)
+    public Rescue(ILogger<Rescue> logger, IRandomManager randomManager)
+        : base(logger, randomManager)
     {
     }
 

--- a/Mud.Server.Rom24/Skills/Sneak.cs
+++ b/Mud.Server.Rom24/Skills/Sneak.cs
@@ -30,8 +30,8 @@ public class Sneak : NoTargetSkillBase
 
     private IAuraManager AuraManager { get; }
 
-    public Sneak(ILogger<Sneak> logger, IRandomManager randomManager, IAbilityManager abilityManager, IAuraManager auraManager)
-        : base(logger, randomManager, abilityManager)
+    public Sneak(ILogger<Sneak> logger, IRandomManager randomManager, IAuraManager auraManager)
+        : base(logger, randomManager)
     {
         AuraManager = auraManager;
     }

--- a/Mud.Server.Rom24/Skills/Steal.cs
+++ b/Mud.Server.Rom24/Skills/Steal.cs
@@ -37,8 +37,8 @@ public class Steal : SkillBase
     private IGameActionManager GameActionManager { get; }
     private int MaxLevel { get; }
 
-    public Steal(ILogger<Steal> logger, IRandomManager randomManager, IAbilityManager abilityManager, IGameActionManager gameActionManager, IOptions<WorldOptions> worldOptions)
-        : base(logger, randomManager, abilityManager)
+    public Steal(ILogger<Steal> logger, IRandomManager randomManager, IGameActionManager gameActionManager, IOptions<WorldOptions> worldOptions)
+        : base(logger, randomManager)
     {
         GameActionManager = gameActionManager;
         MaxLevel = worldOptions.Value.MaxLevel;

--- a/Mud.Server.Rom24/Skills/Trip.cs
+++ b/Mud.Server.Rom24/Skills/Trip.cs
@@ -25,8 +25,8 @@ public class Trip : OffensiveSkillBase
 {
     private const string SkillName = "Trip";
 
-    public Trip(ILogger<Trip> logger, IRandomManager randomManager, IAbilityManager abilityManager)
-        : base(logger, randomManager, abilityManager)
+    public Trip(ILogger<Trip> logger, IRandomManager randomManager)
+        : base(logger, randomManager)
     {
     }
 

--- a/TODO.txt
+++ b/TODO.txt
@@ -1,7 +1,9 @@
 INGOING
 DONE
-    maul: next hit does more damage -> only on white damage (HitDamage) and not yellow damage (AbilityDamage)
-    https://www.wowhead.com/classic/spell=6807/maul
+    Add new game action for skill and assign guards there
+    Don't use ability manager in skillbase anymore
+    Don't create anymore SkillActionInput in SkillBase but in GameActionManager to simulate a similar behavior as Spells using Cast to create SpellActionInput
+    Guards for skills don't have to be check in SkillBase because SkillBase are always linked to a command
 
 ==========
 == TODO ==
@@ -28,8 +30,8 @@ new combat system
     kill reward
         first group to hit the mob will receive the reward
         if everyone in the group has been killed, reward priority goes to next group which has hit the mob
-threat/aggro (see Generating Threat)
-https://www.wowhead.com/classic/guide/threat-overview-classic-wow
+    threat/aggro (see Generating Threat)
+    https://www.wowhead.com/classic/guide/threat-overview-classic-wow
 
 limbo/autoquit timer
 


### PR DESCRIPTION
    Add new game action for skill and assign guards there
    Don't use ability manager in skillbase anymore
    Don't create anymore SkillActionInput in SkillBase but in GameActionManager to simulate a similar behavior as Spells using Cast to create SpellActionInput
    Guards for skills don't have to be check in SkillBase because SkillBase are always linked to a command
close #221 