### PR TITLE
#227

### DIFF
--- a/Datas/Admins/sinac.json
+++ b/Datas/Admins/sinac.json
@@ -1001,8 +1001,8 @@
       "Sex": 1,
       "Size": 2,
       "CurrentResources": {
-		"HitPoints": 3800,
-		"MovePoints": 12000,
+        "HitPoints": 3800,
+        "MovePoints": 12000,
         "Mana": 3151,
         "Psy": 100,
         "Energy": 0,
@@ -1010,8 +1010,8 @@
         "Combo": 0
       },
       "MaxResources": {
-		"HitPoints": 38000,
-		"MovePoints": 13800,
+        "HitPoints": 38000,
+        "MovePoints": 13800,
         "Mana": 10000,
         "Psy": 100,
         "Energy": 0,
@@ -2190,8 +2190,8 @@
       "Sex": 0,
       "Size": 2,
       "CurrentResources": {
-		"HitPoints": 15800,
-		"MovePoints": 1110,
+        "HitPoints": 15800,
+        "MovePoints": 1110,
         "Mana": 5298,
         "Psy": 100,
         "Energy": 100,
@@ -2199,8 +2199,8 @@
         "Combo": 0
       },
       "MaxResources": {
-		"HitPoints": 21800,
-		"MovePoints": 2110,
+        "HitPoints": 21800,
+        "MovePoints": 2110,
         "Mana": 31600,
         "Psy": 100,
         "Energy": 100,
@@ -2557,14 +2557,14 @@
     },
     {
       "CreationTime": "2025-12-07T00:41:18.0014667+01:00",
-      "RoomId": 3054,
-      "SilverCoins": 130,
-      "GoldCoins": 5000,
+      "RoomId": 9418,
+      "SilverCoins": 234,
+      "GoldCoins": 5002,
       "Wimpy": 0,
-      "Experience": 3367,
-      "Alignment": 0,
-      "Trains": 32,
-      "Practices": 54,
+      "Experience": 6077,
+      "Alignment": 47,
+      "Trains": 34,
+      "Practices": 58,
       "AutoFlags": 127,
       "CurrentQuests": [],
       "LearnedAbilities": [
@@ -2601,7 +2601,7 @@
         {
           "Name": "second attack",
           "Level": 5,
-          "Learned": 0,
+          "Learned": 35,
           "Rating": 3
         },
         {
@@ -2711,9 +2711,9 @@
       ],
       "Conditions": {
         "Drunk": 0,
-        "Full": 0,
-        "Thirst": 23,
-        "Hunger": 0
+        "Full": 36,
+        "Thirst": 40,
+        "Hunger": 39
       },
       "Aliases": {},
       "Cooldowns": {},
@@ -2721,22 +2721,22 @@
       "Name": "fnar",
       "Race": "giant",
       "Class": "warrior",
-      "Level": 4,
+      "Level": 6,
       "Sex": 1,
       "Size": 3,
       "CurrentResources": {
-		"HitPoints": 78,
-		"MovePoints": 3,
-        "Mana": 126,
+        "HitPoints": 86,
+        "MovePoints": 55,
+        "Mana": 182,
         "Psy": 100,
         "Energy": 0,
         "Rage": 0,
         "Combo": 0
       },
       "MaxResources": {
-	    "HitPoints": 138,
-		"MovePoints": 138,
-        "Mana": 126,
+        "HitPoints": 171,
+        "MovePoints": 171,
+        "Mana": 182,
         "Psy": 100,
         "Energy": 0,
         "Rage": 0,
@@ -2747,7 +2747,7 @@
           "Slot": 1,
           "Item": {
             "$type": "light",
-            "TimeLeft": 11975,
+            "TimeLeft": 11944,
             "ItemId": 3716,
             "Level": 0,
             "DecayPulseLeft": 0,
@@ -2758,30 +2758,30 @@
         {
           "Slot": 2,
           "Item": {
-            "ItemId": 3706,
-            "Level": 0,
+            "ItemId": 102,
+            "Level": 3,
             "DecayPulseLeft": 0,
-            "ItemFlags": "MeltOnDrop",
+            "ItemFlags": "",
             "Auras": []
           }
         },
         {
           "Slot": 3,
           "Item": {
-            "ItemId": 3705,
-            "Level": 0,
+            "ItemId": 104,
+            "Level": 5,
             "DecayPulseLeft": 0,
-            "ItemFlags": "MeltOnDrop",
+            "ItemFlags": "Glowing",
             "Auras": []
           }
         },
         {
           "Slot": 3,
           "Item": {
-            "ItemId": 3705,
-            "Level": 0,
+            "ItemId": 104,
+            "Level": 5,
             "DecayPulseLeft": 0,
-            "ItemFlags": "MeltOnDrop",
+            "ItemFlags": "Glowing",
             "Auras": []
           }
         },
@@ -2900,12 +2900,10 @@
       ],
       "Inventory": [
         {
-          "$type": "weapon",
-          "WeaponFlags": "",
-          "ItemId": 3702,
-          "Level": 1,
+          "ItemId": 107,
+          "Level": 0,
           "DecayPulseLeft": 0,
-          "ItemFlags": "MeltOnDrop",
+          "ItemFlags": "",
           "Auras": []
         },
         {
@@ -2916,63 +2914,64 @@
           "Auras": []
         },
         {
-          "ItemId": 3712,
-          "Level": 0,
-          "DecayPulseLeft": 0,
-          "ItemFlags": "MeltOnDrop",
-          "Auras": []
-        },
-        {
-          "ItemId": 3707,
-          "Level": 0,
-          "DecayPulseLeft": 0,
-          "ItemFlags": "MeltOnDrop",
-          "Auras": []
-        },
-        {
           "ItemId": 3162,
           "Level": 0,
           "DecayPulseLeft": 0,
           "ItemFlags": "",
           "Auras": []
-        }
-      ],
-      "Auras": [
-        {
-          "AbilityName": "Armor",
-          "Level": 1,
-          "PulseLeft": 4480,
-          "AuraFlags": 0,
-          "Affects": [
-            {
-              "$type": "characterAttribute",
-              "Operator": 0,
-              "Location": 14,
-              "Modifier": -20
-            }
-          ]
         },
         {
-          "AbilityName": "Bless",
-          "Level": 1,
-          "PulseLeft": 9772,
-          "AuraFlags": 0,
-          "Affects": [
-            {
-              "$type": "characterAttribute",
-              "Operator": 0,
-              "Location": 9,
-              "Modifier": 5
-            },
-            {
-              "$type": "characterAttribute",
-              "Operator": 0,
-              "Location": 8,
-              "Modifier": -5
-            }
-          ]
+          "$type": "weapon",
+          "WeaponFlags": "",
+          "ItemId": 103,
+          "Level": 3,
+          "DecayPulseLeft": 0,
+          "ItemFlags": "",
+          "Auras": []
+        },
+        {
+          "ItemId": 107,
+          "Level": 0,
+          "DecayPulseLeft": 0,
+          "ItemFlags": "",
+          "Auras": []
+        },
+        {
+          "ItemId": 109,
+          "Level": 0,
+          "DecayPulseLeft": 0,
+          "ItemFlags": "",
+          "Auras": []
+        },
+        {
+          "$type": "weapon",
+          "WeaponFlags": "",
+          "ItemId": 103,
+          "Level": 3,
+          "DecayPulseLeft": 0,
+          "ItemFlags": "",
+          "Auras": []
+        },
+        {
+          "ItemId": 109,
+          "Level": 0,
+          "DecayPulseLeft": 0,
+          "ItemFlags": "",
+          "Auras": []
+        },
+        {
+          "$type": "wand",
+          "MaxChargeCount": 1,
+          "CurrentChargeCount": 1,
+          "AlreadyRecharged": false,
+          "ItemId": 106,
+          "Level": 3,
+          "DecayPulseLeft": 0,
+          "ItemFlags": "",
+          "Auras": []
         }
       ],
+      "Auras": [],
       "CharacterFlags": "",
       "Immunities": "",
       "Resistances": "Fire,Cold",

--- a/ISSUES.txt
+++ b/ISSUES.txt
@@ -64,8 +64,6 @@ TableGenerator with duplicate column and merge on same value doesn't work
 when mud restarts and a player with quests reconnects, quest items are not recreated
   same goes if player destroy item, it cannot be found in world anymore
 
-extra description not handled correctly (see item 3040)
-
 mystery resets are totally messed up
 
 MYSTERY AREA ISSUES:

--- a/Mud.Blueprints/ExtraDescription.cs
+++ b/Mud.Blueprints/ExtraDescription.cs
@@ -1,0 +1,7 @@
+﻿namespace Mud.Blueprints;
+
+public class ExtraDescription
+{
+    public string[] Keywords { get; set; } = [];
+    public string Description { get; set; } = string.Empty;
+}

--- a/Mud.Blueprints/Item/ItemBlueprintBase.cs
+++ b/Mud.Blueprints/Item/ItemBlueprintBase.cs
@@ -43,7 +43,7 @@ public abstract class ItemBlueprintBase
     public bool NoTake { get; set; }
 
     [DataMember]
-    public Lookup<string, string> ExtraDescriptions { get; set; } = default!; // keyword -> descriptions
+    public ExtraDescription[] ExtraDescriptions { get; set; } = []; // keywords (separated with blank space) -> description
 
     // TODO: flags, level, ...
 
@@ -53,9 +53,13 @@ public abstract class ItemBlueprintBase
     [DataMember]
     public IItemFlags ItemFlags { get; set; } = default!;
 
-    public static Lookup<string,string> BuildExtraDescriptions(IEnumerable<KeyValuePair<string, string>> extraDescriptions)
+    public static ExtraDescription[] BuildExtraDescriptions(IEnumerable<KeyValuePair<string, string>> extraDescriptions)
     {
-        return (Lookup<string, string>)extraDescriptions.SelectMany(x => x.Key.Split(' '), (kv, key) => new { key, desc = kv.Value }).ToLookup(x => x.key, x => x.desc);
+        return extraDescriptions.Select(x => new ExtraDescription
+        {
+            Keywords = x.Key.Split(' ', StringSplitOptions.RemoveEmptyEntries),
+            Description = x.Value
+        }).ToArray();
     }
 
     public bool Equals(ItemBlueprintBase? other)

--- a/Mud.Blueprints/Room/RoomBlueprint.cs
+++ b/Mud.Blueprints/Room/RoomBlueprint.cs
@@ -21,7 +21,7 @@ public class RoomBlueprint
     public string Description { get; set; } = default!;
 
     [DataMember]
-    public Lookup<string, string> ExtraDescriptions { get; set; } = default!; // keyword -> descriptions
+    public ExtraDescription[] ExtraDescriptions { get; set; } = []; // keyword -> descriptions
 
     [DataMember]
     public IRoomFlags RoomFlags { get; set; } = default!;
@@ -44,8 +44,12 @@ public class RoomBlueprint
     [DataMember]
     public List<ResetBase> Resets { get; set; } = [];
 
-    public static Lookup<string, string> BuildExtraDescriptions(IEnumerable<KeyValuePair<string, string>> extraDescriptions)
+    public static ExtraDescription[] BuildExtraDescriptions(IEnumerable<KeyValuePair<string, string>> extraDescriptions)
     {
-        return (Lookup<string, string>)extraDescriptions.SelectMany(x => x.Key.Split(' '), (kv, key) => new { key, desc = kv.Value }).ToLookup(x => x.key, x => x.desc);
+        return extraDescriptions.Select(x => new ExtraDescription
+        {
+            Keywords = x.Key.Split(' ', StringSplitOptions.RemoveEmptyEntries),
+            Description = x.Value
+        }).ToArray();
     }
 }

--- a/Mud.Common/DictionaryExtensions.cs
+++ b/Mud.Common/DictionaryExtensions.cs
@@ -9,4 +9,13 @@ public static class DictionaryExtensions
         else
             dictionary.Add(key, 1);
     }
+
+    public static TValue? GetValueOrDefault<TKey, TValue>(this Dictionary<TKey, TValue> dictionary, TKey key)
+        where TKey: notnull
+        where TValue: class
+    {
+        if (dictionary.TryGetValue(key, out var value))
+            return value;
+        return null;
+    }
 }

--- a/Mud.DataStructures.Tests/ArrayByEnumTests.cs
+++ b/Mud.DataStructures.Tests/ArrayByEnumTests.cs
@@ -1,0 +1,91 @@
+﻿namespace Mud.DataStructures.Tests;
+
+[TestClass]
+public class ArrayByEnumTests
+{
+    [TestMethod]
+    public void Ctor_NoGap()
+    {
+        ArrayByEnum<int, TestEnum_NoGap> arrayByEnum = new();
+
+        Assert.IsNotNull(arrayByEnum);
+        Assert.HasCount(3, arrayByEnum);
+    }
+
+    [TestMethod]
+    public void SetAtIndex_NoGap()
+    {
+        ArrayByEnum<int, TestEnum_NoGap> arrayByEnum = new();
+
+        arrayByEnum[TestEnum_NoGap.First] = 10;
+
+        Assert.IsNotNull(arrayByEnum);
+        Assert.HasCount(3, arrayByEnum);
+        Assert.Contains(10, arrayByEnum);
+    }
+
+    [TestMethod]
+    public void GetAtIndex_NoGap()
+    {
+        ArrayByEnum<int, TestEnum_NoGap> arrayByEnum = new();
+        arrayByEnum[TestEnum_NoGap.First] = 10;
+        arrayByEnum[TestEnum_NoGap.Second] = 0;
+        arrayByEnum[TestEnum_NoGap.Third] = -17;
+
+        Assert.IsNotNull(arrayByEnum);
+        Assert.HasCount(3, arrayByEnum);
+        Assert.AreEqual(10, arrayByEnum[TestEnum_NoGap.First]);
+        Assert.AreEqual(0, arrayByEnum[TestEnum_NoGap.Second]);
+        Assert.AreEqual(-17, arrayByEnum[TestEnum_NoGap.Third]);
+    }
+
+    [TestMethod]
+    public void Ctor_WithGaps()
+    {
+        ArrayByEnum<int, TestEnumWithGaps> arrayByEnum = new();
+
+        Assert.IsNotNull(arrayByEnum);
+        Assert.HasCount(3, arrayByEnum);
+    }
+
+    [TestMethod]
+    public void SetAtIndex_WithGaps()
+    {
+        ArrayByEnum<int, TestEnumWithGaps> arrayByEnum = new();
+
+        arrayByEnum[TestEnumWithGaps.First] = 10;
+
+        Assert.IsNotNull(arrayByEnum);
+        Assert.HasCount(3, arrayByEnum);
+        Assert.Contains(10, arrayByEnum);
+    }
+
+    [TestMethod]
+    public void GetAtIndex_WithGaps()
+    {
+        ArrayByEnum<int, TestEnumWithGaps> arrayByEnum = new();
+        arrayByEnum[TestEnumWithGaps.First] = 10;
+        arrayByEnum[TestEnumWithGaps.Second] = 0;
+        arrayByEnum[TestEnumWithGaps.Third] = -17;
+
+        Assert.IsNotNull(arrayByEnum);
+        Assert.HasCount(3, arrayByEnum);
+        Assert.AreEqual(10, arrayByEnum[TestEnumWithGaps.First]);
+        Assert.AreEqual(0, arrayByEnum[TestEnumWithGaps.Second]);
+        Assert.AreEqual(-17, arrayByEnum[TestEnumWithGaps.Third]);
+    }
+
+    public enum TestEnum_NoGap
+    {
+        First = 0,
+        Second = 1,
+        Third = 2
+    }
+
+    public enum TestEnumWithGaps
+    {
+        First = -7,
+        Second = 0,
+        Third = 4
+    }
+}

--- a/Mud.DataStructures/ArrayByEnum.cs
+++ b/Mud.DataStructures/ArrayByEnum.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections;
+
+namespace Mud.DataStructures;
+
+// https://stackoverflow.com/questions/981776/using-an-enum-as-an-array-index-in-c-sharp
+/// <summary>An array indexed by an Enum</summary>
+/// <typeparam name="T">Type stored in array</typeparam>
+/// <typeparam name="U">Indexer Enum type</typeparam>
+public class ArrayByEnum<T, U> : IEnumerable<T>
+    where U : Enum
+{
+    private readonly T[] _array;
+    private readonly int _lower;
+
+    public ArrayByEnum()
+    {
+        _lower = Convert.ToInt32(Enum.GetValues(typeof(U)).Cast<U>().Min());
+        int upper = Convert.ToInt32(Enum.GetValues(typeof(U)).Cast<U>().Max());
+        _array = new T[1 + upper - _lower];
+    }
+
+    public T this[U key]
+    {
+        get => _array[Convert.ToInt32(key) - _lower];
+        set => _array[Convert.ToInt32(key) - _lower] = value;
+    }
+
+    public IEnumerator<T> GetEnumerator()
+    {
+        return Enum.GetValues(typeof(U)).Cast<U>().Select(i => this[i]).GetEnumerator();
+    }
+
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return GetEnumerator();
+    }
+}

--- a/Mud.Importer.Mystery/MysteryLoader.cs
+++ b/Mud.Importer.Mystery/MysteryLoader.cs
@@ -401,12 +401,12 @@ public class MysteryLoader : TextBasedLoader
                 }
                 else if (letter == 'E')
                 {
-                    string keyword = ReadString();
+                    string keywords = ReadString();
                     string description = ReadString();
-                    if (objectData.ExtraDescr.ContainsKey(keyword))
-                        Logger.LogError("ParseObjects: item [vnum:{vnum}] Extra desc already exists", vnum);
+                    if (objectData.ExtraDescr.ContainsKey(keywords))
+                        Logger.LogError("ParseObjects: item [vnum:{vnum}] Extra desc '{keywords}' already exists", vnum, keywords);
                     else
-                        objectData.ExtraDescr.Add(keyword, description);
+                        objectData.ExtraDescr.Add(keywords, description);
                 }
                 else if (letter == 'Y')
                 {
@@ -643,12 +643,12 @@ public class MysteryLoader : TextBasedLoader
                 }
                 else if (letter == 'E')
                 {
-                    string keyword = ReadString();
+                    string keywords = ReadString();
                     string description = ReadString();
-                    if (roomData.ExtraDescr.ContainsKey(keyword))
-                        Warn("ParseRooms: duplicate description in vnum {0}", vnum);
+                    if (roomData.ExtraDescr.ContainsKey(keywords))
+                        Logger.LogError("ParseRooms: room [vnum:{vnum}] Extra desc '{keywords}' already exists", vnum, keywords);
                     else
-                        roomData.ExtraDescr.Add(keyword, description);
+                        roomData.ExtraDescr.Add(keywords, description);
                 }
                 else if (letter == 'O')
                 {

--- a/Mud.Importer.Rom/RomLoader.cs
+++ b/Mud.Importer.Rom/RomLoader.cs
@@ -426,12 +426,12 @@ public class RomLoader : TextBasedLoader
                 }
                 else if (letter == 'E')
                 {
-                    string keyword = ReadString();
+                    string keywords = ReadString();
                     string description = ReadString();
-                    if (objectData.ExtraDescr.ContainsKey(keyword))
-                        Logger.LogError("ParseObjects: item [vnum:{vnum}] Extra desc '{keyword}' already exists", vnum, keyword);
+                    if (objectData.ExtraDescr.ContainsKey(keywords))
+                        Logger.LogError("ParseObjects: item [vnum:{vnum}] Extra desc '{keywords}' already exists", vnum, keywords);
                     else
-                        objectData.ExtraDescr.Add(keyword, description);
+                        objectData.ExtraDescr.Add(keywords, description);
                 }
                 else if (letter == 'Y')
                 {
@@ -659,12 +659,12 @@ public class RomLoader : TextBasedLoader
                 }
                 else if (letter == 'E')
                 {
-                    string keyword = ReadString();
+                    string keywords = ReadString();
                     string description = ReadString();
-                    if (roomData.ExtraDescr.ContainsKey(keyword))
-                        Warn("ParseRooms: duplicate description in vnum {0}", vnum);
+                    if (roomData.ExtraDescr.ContainsKey(keywords))
+                        Logger.LogError("ParseRooms: room [vnum:{vnum}] Extra desc '{keywords}' already exists", vnum, keywords);
                     else
-                        roomData.ExtraDescr.Add(keyword, description);
+                        roomData.ExtraDescr.Add(keywords, description);
                 }
                 else if (letter == 'O')
                 {

--- a/Mud.Importer.Rot/RotLoader.cs
+++ b/Mud.Importer.Rot/RotLoader.cs
@@ -395,12 +395,12 @@ public class RotLoader : TextBasedLoader
                 }
                 else if (letter == 'E')
                 {
-                    string keyword = ReadString();
+                    string keywords = ReadString();
                     string description = ReadString();
-                    if (objectData.ExtraDescr.ContainsKey(keyword))
-                        Logger.LogError("ParseObjects: item [vnum:{vnum}] Extra desc '{keyword}' already exists", vnum, keyword);
+                    if (objectData.ExtraDescr.ContainsKey(keywords))
+                        Logger.LogError("ParseObjects: item [vnum:{vnum}] Extra desc '{keywords}' already exists", vnum, keywords);
                     else
-                        objectData.ExtraDescr.Add(keyword, description);
+                        objectData.ExtraDescr.Add(keywords, description);
                 }
                 else if (letter == 'C')
                 {
@@ -660,12 +660,12 @@ public class RotLoader : TextBasedLoader
                 }
                 else if (letter == 'E')
                 {
-                    string keyword = ReadString();
+                    string keywords = ReadString();
                     string description = ReadString();
-                    if (roomData.ExtraDescr.ContainsKey(keyword))
-                        Warn("ParseRooms: duplicate description in vnum {0}", vnum);
+                    if (roomData.ExtraDescr.ContainsKey(keywords))
+                        Logger.LogError("ParseRooms: room [vnum:{vnum}] Extra desc '{keywords}' already exists", vnum, keywords);
                     else
-                        roomData.ExtraDescr.Add(keyword, description);
+                        roomData.ExtraDescr.Add(keywords, description);
                 }
                 else if (letter == 'O')
                 {

--- a/Mud.Server.Ability/AbilityGroup/AbilityGroupManager.cs
+++ b/Mud.Server.Ability/AbilityGroup/AbilityGroupManager.cs
@@ -29,14 +29,7 @@ namespace Mud.Server.Ability.AbilityGroup
         public IEnumerable<IAbilityGroupDefinition> AbilityGroups => _abilityGroupByName.Values;
 
         public IAbilityGroupDefinition? this[string abilityGroupName]
-        {
-            get
-            {
-                if (!_abilityGroupByName.TryGetValue(abilityGroupName, out var abilityGroupDefinition))
-                    return null;
-                return abilityGroupDefinition;
-            }
-        }
+            => _abilityGroupByName.GetValueOrDefault(abilityGroupName);
 
         public IAbilityGroupDefinition? Search(ICommandParameter parameter)
             => AbilityGroups.FirstOrDefault(x => StringCompareHelpers.StringStartsWith(x.Name, parameter.Value));

--- a/Mud.Server.Class/ClassManager.cs
+++ b/Mud.Server.Class/ClassManager.cs
@@ -26,9 +26,7 @@ public class ClassManager : IClassManager
         {
             if (string.IsNullOrWhiteSpace(name))
                 return null;
-            if (_classByNames.TryGetValue(name, out var c))
-                return c;
-            return null;
+            return _classByNames.GetValueOrDefault(name);
         }
     }
 

--- a/Mud.Server.Commands/Actor/Help.cs
+++ b/Mud.Server.Commands/Actor/Help.cs
@@ -160,7 +160,7 @@ public class Help : ActorGameAction
     {
         // displayed as skill and replace [cmd] with command names
         var iSkillType = typeof(ISkill);
-        foreach (var abilityDefinition in AbilityManager.SearchAbilities<ISkill>().Where(x => nameFilterFunc(x.Name)).OrderBy(x => x.Name))
+        foreach (var abilityDefinition in AbilityManager.SearchAbilitiesByExecutionType<ISkill>().Where(x => nameFilterFunc(x.Name)).OrderBy(x => x.Name))
         {
             // search game action infos matching skill
             var gameActionInfos = Actor.GameActions.Where(x => x.Value.CommandExecutionType == abilityDefinition.AbilityExecutionType);
@@ -187,7 +187,7 @@ public class Help : ActorGameAction
     private void AppendAbilities<TAbility>(StringBuilder sb, Func<string, bool> nameFilterFunc)
         where TAbility: class, IAbility
     {
-        foreach (var abilityDefinition in AbilityManager.SearchAbilities<TAbility>().Where(x => nameFilterFunc(x.Name)).OrderBy(x => x.Name))
+        foreach (var abilityDefinition in AbilityManager.SearchAbilitiesByExecutionType<TAbility>().Where(x => nameFilterFunc(x.Name)).OrderBy(x => x.Name))
         {
             sb.AppendLine($"%W%{abilityDefinition.Name}%x% [{abilityDefinition.Type}]");
             if (abilityDefinition.Syntax != null)

--- a/Mud.Server.Commands/Admin/Information/Cstat.cs
+++ b/Mud.Server.Commands/Admin/Information/Cstat.cs
@@ -84,6 +84,11 @@ public class Cstat : AdminGameAction
             sb.AppendLine("No blueprint");
         sb.AppendFormatLine("Name: {0} Keywords: {1}", Whom.Name, string.Join(",", Whom.Keywords));
         sb.AppendFormatLine("DisplayName: {0}", Whom.DisplayName);
+        if (nonPlayableWhom?.Blueprint != null)
+        {
+            sb.AppendFormatLine("ShortDescription: {0}", nonPlayableWhom.Blueprint.ShortDescription);
+            sb.AppendFormatLine("LongDescription: {0}", nonPlayableWhom.Blueprint.LongDescription);
+        }
         sb.AppendFormatLine("Description: {0}", Whom.Description);
         if (Whom.Leader != null)
             sb.AppendFormatLine("Leader: {0}", Whom.Leader.DisplayName);

--- a/Mud.Server.Commands/Admin/Information/Iinfo.cs
+++ b/Mud.Server.Commands/Admin/Information/Iinfo.cs
@@ -53,12 +53,8 @@ public class Iinfo : AdminGameAction
         sb.AppendFormatLine("Flags: {0} WearLocation: {1}", Blueprint.ItemFlags, Blueprint.WearLocation);
         if (Blueprint.ExtraDescriptions != null)
         {
-            foreach (var lookup in Blueprint.ExtraDescriptions)
-                foreach (string extraDescr in lookup)
-                {
-                    sb.AppendFormatLine("ExtraDescription: {0}", lookup.Key);
-                    sb.AppendLine(extraDescr);
-                }
+            foreach (var extraDescription in Blueprint.ExtraDescriptions)
+                sb.AppendFormatLine("ExtraDescription: {0} " + Environment.NewLine + "{1}", string.Join(",", extraDescription.Keywords), extraDescription.Description);
         }
         switch (Blueprint)
         {

--- a/Mud.Server.Commands/Admin/Information/Istat.cs
+++ b/Mud.Server.Commands/Admin/Information/Istat.cs
@@ -52,12 +52,12 @@ public class Istat : AdminGameAction
         sb.AppendFormatLine("Type: {0}", What.GetType().ToString().AfterLast('.'));
         sb.AppendFormatLine("Name: {0} Keywords: {1}", What.Name, string.Join(",", What.Keywords));
         sb.AppendFormatLine("DisplayName: {0}", What.DisplayName);
+        sb.AppendFormatLine("ShortDescription: {0}", What.Blueprint.ShortDescription);
         sb.AppendFormatLine("Description: {0}", What.Description);
         if (What.ExtraDescriptions != null)
         {
-            foreach (var lookup in What.ExtraDescriptions)
-                foreach (string extraDescr in lookup)
-                    sb.AppendFormatLine("ExtraDescription: {0} " + Environment.NewLine + "{1}", lookup.Key, extraDescr);
+            foreach (var extraDescription in What.ExtraDescriptions)
+                sb.AppendFormatLine("ExtraDescription: {0} " + Environment.NewLine + "{1}", string.Join(",", extraDescription.Keywords), extraDescription.Description);
         }
         sb.AppendFormatLine("Type: {0}", What.GetType().Name);
         if (What.IncarnatedBy != null)

--- a/Mud.Server.Commands/Admin/Information/Rstat.cs
+++ b/Mud.Server.Commands/Admin/Information/Rstat.cs
@@ -61,9 +61,8 @@ public class Rstat : AdminGameAction
         sb.AppendFormatLine("Heal rate: {0}% (base {1}%) Resource rate: {2}% (base {3}%)", Room.HealRate, Room.BaseHealRate, Room.ResourceRate, Room.BaseResourceRate);
         if (Room.ExtraDescriptions != null)
         {
-            foreach (var lookup in Room.ExtraDescriptions)
-                foreach (string extraDescr in lookup)
-                    sb.AppendFormatLine("ExtraDescription: {0} " + Environment.NewLine + "{1}", lookup.Key, extraDescr);
+            foreach (var extraDescription in Room.ExtraDescriptions)
+                sb.AppendFormatLine("ExtraDescription: {0} " + Environment.NewLine + "{1}", string.Join(",", extraDescription.Keywords), extraDescription.Description);
         }
         foreach (ExitDirections direction in Enum.GetValues<ExitDirections>())
         {

--- a/Mud.Server.Commands/Character/Information/Equipment.cs
+++ b/Mud.Server.Commands/Character/Information/Equipment.cs
@@ -23,11 +23,13 @@ public class Equipment : CharacterGameAction
                 sb.Append(where);
                 if (equippedItem.Item == null)
                     sb.AppendLine("nothing");
-                else
+                else if (Actor.CanSee(equippedItem.Item))
                 {
                     equippedItem.Item.Append(sb, Actor, true);
                     sb.AppendLine();
                 }
+                else
+                    sb.AppendLine("something");
             }
         }
 

--- a/Mud.Server.Common/Helpers/ItemsHelpers.cs
+++ b/Mud.Server.Common/Helpers/ItemsHelpers.cs
@@ -9,7 +9,7 @@ public static class ItemsHelpers
 {
     public static StringBuilder AppendItems(StringBuilder sb, IEnumerable<IItem> items, ICharacter actor, bool shortDisplay, bool displayNothing) // equivalent to act_info.C:show_list_to_char
     {
-        var enumerable = items as IItem[] ?? items.ToArray();
+        var enumerable = items.Where(actor.CanSee).ToArray();
         if (displayNothing && enumerable.Length == 0)
             sb.AppendLine("Nothing.");
         else

--- a/Mud.Server.GameAction/CommandParser.cs
+++ b/Mud.Server.GameAction/CommandParser.cs
@@ -135,7 +135,7 @@ public class CommandParser : ICommandParser
         int dotIndex = parameter.IndexOf('.');
         if (dotIndex < 0)
         {
-            bool isAll = string.Equals(parameter, "all", StringComparison.InvariantCultureIgnoreCase);
+            bool isAll = StringCompareHelpers.StringEquals(parameter, "all");
             return isAll
                     ? new CommandParameter(parameter, parameter, true, true) // all
                     : new CommandParameter(parameter, parameter, 1);
@@ -144,7 +144,7 @@ public class CommandParser : ICommandParser
             return CommandParameter.InvalidCommandParameter; // only . is invalid
         string countAsString = parameter[..dotIndex];
         string value = parameter[(dotIndex + 1)..];
-        bool isCountAll = string.Equals(countAsString, "all", StringComparison.InvariantCultureIgnoreCase);
+        bool isCountAll = StringCompareHelpers.StringEquals(countAsString, "all");
         if (isCountAll)
             return new CommandParameter(parameter, value, true, false); // all.xxx
         if (!int.TryParse(countAsString, out int count)) // string.string is not splitted

--- a/Mud.Server.GameAction/GameActionManager.cs
+++ b/Mud.Server.GameAction/GameActionManager.cs
@@ -128,7 +128,7 @@ public class GameActionManager : IGameActionManager
             .OrderBy(g => g.Key)
             .Select(g => PolymorphismSimulator(actorType, iActorType, actorTypeSortedImplementedInterfaces, g.Key, g, x => x.CommandExecutionType)).ToArray();
         // one entry using CommandAttribute.Name and one entry by AliasAttribute.Alias
-        var staticEntries = staticGameActionInfos.Where(x => x != null).SelectMany(x => x!.Names, (gameActionInfo, name) => new TrieEntry<IGameActionInfo>(name, gameActionInfo!));
+        var staticEntries = staticGameActionInfos.Where(x => x != null).SelectMany(x => x!.Names, (gameActionInfo, name) => new TrieEntry<IGameActionInfo>(name.ToLowerInvariant(), gameActionInfo!));
 
         // dynamic game action infos
         var dynamicGameActionInfos = _dynamicGameActionInfos
@@ -142,7 +142,7 @@ public class GameActionManager : IGameActionManager
             // search if a static game action info with the same exists
             var existingStaticGameActionInfoWithSameNameOrAlias = staticGameActionInfos.FirstOrDefault(x => x is not null && StringCompareHelpers.AnyStringEquals(x.Names, dynamicGameInfoAction!.Name));
             if (existingStaticGameActionInfoWithSameNameOrAlias == null)
-                dynamicEntries.Add(new TrieEntry<IGameActionInfo>(dynamicGameInfoAction!.Name, dynamicGameInfoAction!));
+                dynamicEntries.Add(new TrieEntry<IGameActionInfo>(dynamicGameInfoAction!.Name.ToLowerInvariant(), dynamicGameInfoAction!));
             else
                 Logger.LogError("GameActionManager: dynamic command {dynamicName} conflicts with static command {staticName} -> keeps static one", dynamicGameInfoAction!.Name, existingStaticGameActionInfoWithSameNameOrAlias.Name);
         }

--- a/Mud.Server.Interfaces/Ability/IAbilityManager.cs
+++ b/Mud.Server.Interfaces/Ability/IAbilityManager.cs
@@ -11,8 +11,6 @@ namespace Mud.Server.Interfaces.Ability
         IAbilityDefinition? this[Type abilityType] { get; }
         IAbilityDefinition? this[WeaponTypes weaponType] { get; }
 
-        IEnumerable<IAbilityDefinition> SearchAbilities<TAbility>()
-            where TAbility: class, IAbility;
         IEnumerable<IAbilityDefinition> SearchAbilitiesByExecutionType<TAbility>()
             where TAbility : class, IAbility;
 

--- a/Mud.Server.Interfaces/Item/IItem.cs
+++ b/Mud.Server.Interfaces/Item/IItem.cs
@@ -1,6 +1,7 @@
-﻿using Mud.Domain;
-using Mud.Domain.SerializationData;
+﻿using Mud.Blueprints;
 using Mud.Blueprints.Item;
+using Mud.Domain;
+using Mud.Domain.SerializationData;
 using Mud.Server.Flags.Interfaces;
 using Mud.Server.Interfaces.Affect.Item;
 using Mud.Server.Interfaces.Character;
@@ -24,7 +25,7 @@ public interface IItem : IEntity
 
     ItemBlueprintBase Blueprint { get; }
 
-    ILookup<string, string> ExtraDescriptions { get; } // keyword -> descriptions
+    IEnumerable<ExtraDescription> ExtraDescriptions { get; }
 
     WearLocations WearLocation { get; }
     ICharacter? EquippedBy { get; }

--- a/Mud.Server.Interfaces/Room/IRoom.cs
+++ b/Mud.Server.Interfaces/Room/IRoom.cs
@@ -1,6 +1,7 @@
-﻿using Mud.Domain;
+﻿using Mud.Blueprints;
 using Mud.Blueprints.Character;
 using Mud.Blueprints.Room;
+using Mud.Domain;
 using Mud.Server.Flags.Interfaces;
 using Mud.Server.Interfaces.Affect.Room;
 using Mud.Server.Interfaces.Area;
@@ -17,7 +18,7 @@ public interface IRoom : IEntity, IContainer
 
     RoomBlueprint Blueprint { get; }
 
-    ILookup<string, string> ExtraDescriptions { get; } // keyword -> descriptions
+    IEnumerable<ExtraDescription> ExtraDescriptions { get; }
 
     IRoomFlags BaseRoomFlags { get; }
     IRoomFlags RoomFlags { get; }

--- a/Mud.Server.Quest/QuestManager.cs
+++ b/Mud.Server.Quest/QuestManager.cs
@@ -1,8 +1,8 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Mud.Blueprints.Quest;
 using Mud.Common.Attributes;
 using Mud.Domain.SerializationData;
-using Mud.Blueprints.Quest;
 using Mud.Server.Interfaces.Character;
 using Mud.Server.Interfaces.Quest;
 
@@ -28,17 +28,12 @@ public class QuestManager : IQuestManager
         => _questBlueprints.Values.ToList().AsReadOnly();
 
     public QuestBlueprint? GetQuestBlueprint(int id)
-    {
-        _questBlueprints.TryGetValue(id, out var blueprint);
-        return blueprint;
-    }
+        => _questBlueprints.GetValueOrDefault(id);
 
     public void AddQuestBlueprint(QuestBlueprint blueprint)
     {
-        if (_questBlueprints.ContainsKey(blueprint.Id))
+        if (!_questBlueprints.TryAdd(blueprint.Id, blueprint))
             Logger.LogError("Quest blueprint duplicate {blueprintId}!!!", blueprint.Id);
-        else
-            _questBlueprints.Add(blueprint.Id, blueprint);
     }
 
     public IQuest? AddQuest(QuestBlueprint questBlueprint, IPlayableCharacter pc, INonPlayableCharacter questGiver)

--- a/Mud.Server.Race/RaceManager.cs
+++ b/Mud.Server.Race/RaceManager.cs
@@ -29,9 +29,7 @@ public class RaceManager : IRaceManager
         {
             if (string.IsNullOrWhiteSpace(name))
                 return null;
-            if (_raceByNames.TryGetValue(name, out var r))
-                return r;
-            return null;
+            return _raceByNames.GetValueOrDefault(name);
         }
     }
 

--- a/Mud.Server.Rom24/Flags/CharacterFlagsValues.cs
+++ b/Mud.Server.Rom24/Flags/CharacterFlagsValues.cs
@@ -50,8 +50,6 @@ public class CharacterFlagValues : IFlagValues
         //        "Sneak" => "%R%(S)%x%",
         //        "PassDoor" => "%c%(T)%x%",
         //        "FaerieFire" => "%m%(P)%x%",
-        //        "DetectEvil" => "%r%(R)%x%",
-        //        "DetectGood" => "%Y%(G)%x%",
         //        _ => string.Empty, // we don't want to display the other flags
         //    };
         //else
@@ -64,8 +62,6 @@ public class CharacterFlagValues : IFlagValues
                 "Sneak" => "%R%(Sneaking)%x%",
                 "PassDoor" => "%c%(Translucent)%x%",
                 "FaerieFire" => "%m%(Pink Aura)%x%",
-                "DetectEvil" => "%r%(Red Aura)%x%",
-                "DetectGood" => "%Y%(Golden Aura)%x%",
                 _ => string.Empty, // we don't want to display the other flags
             };
     }

--- a/Mud.Server.Rom24/Specials/CastMage.cs
+++ b/Mud.Server.Rom24/Specials/CastMage.cs
@@ -92,7 +92,7 @@ namespace Mud.Server.Rom24.Specials
         {
             var successfull = caster.CastSpell(spellName, victim);
             if (!successfull)
-                Logger.LogError("CastMage: error on {caster} while casting spell {spellName} on {victimName}", caster.DebugName, spellName, victim.DebugName);
+                Logger.LogWarning("CastMage: {caster} unsuccessfully cast spell {spellName} on {victimName}", caster.DebugName, spellName, victim.DebugName);
             return successfull;
         }
     }

--- a/Mud.Server.Tests/Random/OneHitDiceRollTests.cs
+++ b/Mud.Server.Tests/Random/OneHitDiceRollTests.cs
@@ -1,0 +1,26 @@
+﻿using Mud.Common;
+using Mud.Server.Random;
+
+namespace Mud.Server.Tests.Random;
+
+[TestClass]
+public class OneHitDiceRollTests
+{
+    [TestMethod]
+    public void CheckDiceRoll()
+    {
+        var randomManager = new RandomManager(0);
+
+        var results = new Dictionary<int, int>();
+
+        for (int i = 0; i < 10_000_000; i++)
+        {
+            int diceRoll;
+            while ((diceRoll = randomManager.Range(0, (1 << 5)-1)) >= 20)
+                ;
+            results.Increment(diceRoll);
+        }
+
+
+    }
+}

--- a/Mud.Server.WPFTestApplication/appsettings.json
+++ b/Mud.Server.WPFTestApplication/appsettings.json
@@ -55,9 +55,9 @@
     "Importer": "RomImporter",
     "Path": "D:\\Projects\\Repos\\Mud.Net\\Datas\\Areas\\Rom24\\",
     //"Path": "C:\\PRJ\\Personal\\SinaC\\Mud.Net\\Datas\\Areas\\Rom24\\"
-    "Areas": [ "limbo.are", "midgaard.are", "smurf.are", "hitower.are", "hood.are", "school.are", "ofcol2.are" ]
+    //"Areas": [ "limbo.are", "midgaard.are", "smurf.are", "hitower.are", "hood.are", "school.are", "ofcol2.are" ]
     //"Areas": [ "limbo.are", "midgaard.are", "sewer.are" ]
-    //"Lists": [ "area.lst" ]
+    "Lists": [ "area.lst" ]
   },
   "Rom24.Settings": {
     "SpellBlueprintIds": {

--- a/Mud.Server/Area/AreaManager.cs
+++ b/Mud.Server/Area/AreaManager.cs
@@ -23,11 +23,9 @@ public class AreaManager : IAreaManager
 
     public IReadOnlyCollection<AreaBlueprint> AreaBlueprints
         => _areaBlueprints.Values.ToList().AsReadOnly();
+
     public AreaBlueprint? GetAreaBlueprint(int id)
-    {
-        _areaBlueprints.TryGetValue(id, out var blueprint);
-        return blueprint;
-    }
+        => _areaBlueprints.GetValueOrDefault(id);
 
     public void AddAreaBlueprint(AreaBlueprint blueprint)
     {

--- a/Mud.Server/Character/CharacterManager.cs
+++ b/Mud.Server/Character/CharacterManager.cs
@@ -1,15 +1,13 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using Mud.Blueprints.Character;
 using Mud.Common.Attributes;
 using Mud.Domain.SerializationData;
-using Mud.Blueprints.Character;
 using Mud.Server.Flags.Interfaces;
-using Mud.Server.Interfaces.Aura;
 using Mud.Server.Interfaces.Character;
 using Mud.Server.Interfaces.Item;
 using Mud.Server.Interfaces.Player;
 using Mud.Server.Interfaces.Room;
-using System.Collections.ObjectModel;
 
 namespace Mud.Server.Character;
 
@@ -41,10 +39,7 @@ public class CharacterManager : ICharacterManager
         => _characterBlueprints.Values.ToList().AsReadOnly();
 
     public CharacterBlueprintBase? GetCharacterBlueprint(int id)
-    {
-        _characterBlueprints.TryGetValue(id, out var blueprint);
-        return blueprint;
-    }
+        => _characterBlueprints.GetValueOrDefault(id);
 
     public TBlueprint? GetCharacterBlueprint<TBlueprint>(int id)
         where TBlueprint : CharacterBlueprintBase
@@ -52,7 +47,7 @@ public class CharacterManager : ICharacterManager
 
     public void AddCharacterBlueprint(CharacterBlueprintBase blueprint)
     {
-        if (_characterBlueprints.ContainsKey(blueprint.Id))
+        if (!_characterBlueprints.TryAdd(blueprint.Id, blueprint))
             Logger.LogError("Character blueprint duplicate {blueprintId}!!!", blueprint.Id);
         else
         {
@@ -69,7 +64,6 @@ public class CharacterManager : ICharacterManager
             checkSuccess &= FlagsManager.CheckFlags(blueprint.BodyParts);
             if (!checkSuccess)
                 Logger.LogError("NPC blueprint {blueprintId} has invalid flags", blueprint.Id);
-            _characterBlueprints.Add(blueprint.Id, blueprint);
         }
     }
 

--- a/Mud.Server/Character/NonPlayableCharacter/NonPlayableCharacter.cs
+++ b/Mud.Server/Character/NonPlayableCharacter/NonPlayableCharacter.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Mud.Blueprints.Character;
+using Mud.Common;
 using Mud.Common.Attributes;
 using Mud.DataStructures.Trie;
 using Mud.Domain;
@@ -539,7 +540,7 @@ public class NonPlayableCharacter : CharacterBase, INonPlayableCharacter
         var spellInstanceGuards = spellInstance.Setup(spellActionInput);
         if (spellInstanceGuards != null)
         {
-            Logger.LogError("NPC:CastSpell: cannot setup spell {spellName} on target {targetName}: {spellInstanceGuards}", spellDefinition.Name, target.Name, spellInstanceGuards);
+            Logger.LogWarning("NPC:CastSpell: cannot setup spell {spellName} on target {targetName}: {spellInstanceGuards}", spellDefinition.Name, target.Name, spellInstanceGuards);
             Send(spellInstanceGuards);
             return false;
         }
@@ -612,64 +613,64 @@ public class NonPlayableCharacter : CharacterBase, INonPlayableCharacter
 
         // TODO: spells
         int learned;
-        if (string.Equals(abilityName, "Sneak", StringComparison.InvariantCultureIgnoreCase) || string.Equals(abilityName, "Hide", StringComparison.InvariantCultureIgnoreCase))
+        if (StringCompareHelpers.StringEquals(abilityName, "Sneak") || StringCompareHelpers.StringEquals(abilityName, "Hide"))
             learned = 20 + 2 * Level;
-        else if (string.Equals(abilityName, "Dodge", StringComparison.InvariantCultureIgnoreCase)
+        else if (StringCompareHelpers.StringEquals(abilityName, "Dodge")
             && OffensiveFlags.IsSet("Dodge"))
             learned = 2 * Level;
-        else if (string.Equals(abilityName, "Parry", StringComparison.InvariantCultureIgnoreCase)
+        else if (StringCompareHelpers.StringEquals(abilityName, "Parry")
             && OffensiveFlags.IsSet("Parry"))
             learned = 2 * Level;
-        else if (string.Equals(abilityName, "Shield Block", StringComparison.InvariantCultureIgnoreCase))
+        else if (StringCompareHelpers.StringEquals(abilityName, "Shield Block"))
             learned = 10 + 2 * Level;
-        else if (string.Equals(abilityName, "Second attack", StringComparison.InvariantCultureIgnoreCase)
+        else if (StringCompareHelpers.StringEquals(abilityName, "Second attack")
             && ActFlags.HasAny("Warrior", "Thief"))
             learned = 10 + 3 * Level;
-        else if (string.Equals(abilityName, "Third attack", StringComparison.InvariantCultureIgnoreCase)
+        else if (StringCompareHelpers.StringEquals(abilityName, "Third attack")
             && ActFlags.IsSet("Warrior"))
             learned = 4 * Level - 40;
-        else if (string.Equals(abilityName, "Hand to hand", StringComparison.InvariantCultureIgnoreCase))
+        else if (StringCompareHelpers.StringEquals(abilityName, "Hand to hand"))
             learned = 40 + 2 * Level;
-        else if (string.Equals(abilityName, "Trip", StringComparison.InvariantCultureIgnoreCase)
+        else if (StringCompareHelpers.StringEquals(abilityName, "Trip")
             && OffensiveFlags.IsSet("Trip"))
             learned = 10 + 3 * Level;
-        else if (string.Equals(abilityName, "Bash", StringComparison.InvariantCultureIgnoreCase)
+        else if (StringCompareHelpers.StringEquals(abilityName, "Bash")
             && OffensiveFlags.IsSet("Bash"))
             learned = 10 + 3 * Level;
-        else if (string.Equals(abilityName, "Disarm", StringComparison.InvariantCultureIgnoreCase)
+        else if (StringCompareHelpers.StringEquals(abilityName, "Disarm")
             && (OffensiveFlags.IsSet("Disarm") || ActFlags.HasAny("Warrior", "Thief")))
             learned = 20 + 3 * Level;
-        else if (string.Equals(abilityName, "Berserk", StringComparison.InvariantCultureIgnoreCase)
+        else if (StringCompareHelpers.StringEquals(abilityName, "Berserk")
             && OffensiveFlags.IsSet("Berserk"))
             learned = 3 * Level;
-        else if (string.Equals(abilityName, "Kick", StringComparison.InvariantCultureIgnoreCase)
+        else if (StringCompareHelpers.StringEquals(abilityName, "Kick")
             && OffensiveFlags.IsSet("Kick"))
             learned = 10 + 3 * Level;
-        else if (string.Equals(abilityName, "Backstab", StringComparison.InvariantCultureIgnoreCase)
+        else if (StringCompareHelpers.StringEquals(abilityName, "Backstab")
             && ActFlags.IsSet("Thief"))
             learned = 20 + 2 * Level;
-        else if (string.Equals(abilityName, "Rescue", StringComparison.InvariantCultureIgnoreCase))
+        else if (StringCompareHelpers.StringEquals(abilityName, "Rescue"))
             learned = 40 + Level;
-        else if (string.Equals(abilityName, "Tail", StringComparison.InvariantCultureIgnoreCase)
+        else if (StringCompareHelpers.StringEquals(abilityName, "Tail")
             && OffensiveFlags.IsSet("Tail"))
             learned = 10 + 3 * Level;
-        else if (string.Equals(abilityName, "Bite", StringComparison.InvariantCultureIgnoreCase)
+        else if (StringCompareHelpers.StringEquals(abilityName, "Bite")
             && OffensiveFlags.IsSet("Bite"))
              learned = 10 + 3 * Level;
-        else if (string.Equals(abilityName, "Crush", StringComparison.InvariantCultureIgnoreCase)
+        else if (StringCompareHelpers.StringEquals(abilityName, "Crush")
             && OffensiveFlags.IsSet("Crush"))
             learned = 10 + 3 * Level;
-        else if (string.Equals(abilityName, "Recall", StringComparison.InvariantCultureIgnoreCase))
+        else if (StringCompareHelpers.StringEquals(abilityName, "Recall"))
             learned = 40 + Level;
-        else if (string.Equals(abilityName, "Axe", StringComparison.InvariantCultureIgnoreCase)
-            || string.Equals(abilityName, "Dagger", StringComparison.InvariantCultureIgnoreCase)
-            || string.Equals(abilityName, "Flail", StringComparison.InvariantCultureIgnoreCase)
-            || string.Equals(abilityName, "Mace", StringComparison.InvariantCultureIgnoreCase)
-            || string.Equals(abilityName, "Polearm", StringComparison.InvariantCultureIgnoreCase)
-            || string.Equals(abilityName, "Spear", StringComparison.InvariantCultureIgnoreCase)
-            || string.Equals(abilityName, "Staff(weapon)", StringComparison.InvariantCultureIgnoreCase)
-            || string.Equals(abilityName, "Sword", StringComparison.InvariantCultureIgnoreCase)
-            || string.Equals(abilityName, "Whip", StringComparison.InvariantCultureIgnoreCase))
+        else if (StringCompareHelpers.StringEquals(abilityName, "Axe")
+            || StringCompareHelpers.StringEquals(abilityName, "Dagger")
+            || StringCompareHelpers.StringEquals(abilityName, "Flail")
+            || StringCompareHelpers.StringEquals(abilityName, "Mace")
+            || StringCompareHelpers.StringEquals(abilityName, "Polearm")
+            || StringCompareHelpers.StringEquals(abilityName, "Spear")
+            || StringCompareHelpers.StringEquals(abilityName, "Staff(weapon)")
+            || StringCompareHelpers.StringEquals(abilityName, "Sword")
+            || StringCompareHelpers.StringEquals(abilityName, "Whip"))
                 learned = 40 + 5 * Level / 2;
         else
             learned = 0;

--- a/Mud.Server/Item/ItemBase.cs
+++ b/Mud.Server/Item/ItemBase.cs
@@ -1,9 +1,10 @@
 ﻿using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Mud.Blueprints;
+using Mud.Blueprints.Item;
 using Mud.Common;
 using Mud.Domain;
 using Mud.Domain.SerializationData;
-using Mud.Blueprints.Item;
 using Mud.Server.Common;
 using Mud.Server.Common.Helpers;
 using Mud.Server.Domain;
@@ -170,7 +171,7 @@ public abstract class ItemBase: EntityBase, IItem
 
     public string ShortDescription { get; private set; } = null!;
 
-    public ILookup<string, string> ExtraDescriptions => Blueprint.ExtraDescriptions;
+    public IEnumerable<ExtraDescription> ExtraDescriptions => Blueprint.ExtraDescriptions;
 
     public WearLocations WearLocation { get; private set; }
 

--- a/Mud.Server/Item/ItemManager.cs
+++ b/Mud.Server/Item/ItemManager.cs
@@ -1,18 +1,16 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Mud.Blueprints.Item;
 using Mud.Common;
 using Mud.Common.Attributes;
 using Mud.Domain.SerializationData;
-using Mud.Blueprints.Item;
 using Mud.Server.Flags.Interfaces;
-using Mud.Server.Interfaces.Aura;
 using Mud.Server.Interfaces.Character;
 using Mud.Server.Interfaces.Entity;
 using Mud.Server.Interfaces.Item;
 using Mud.Server.Interfaces.Room;
 using Mud.Server.Options;
-using System.Collections.ObjectModel;
 using System.Reflection;
 
 namespace Mud.Server.Item;
@@ -70,10 +68,7 @@ public class ItemManager : IItemManager
         => _itemBlueprints.Values.ToList().AsReadOnly();
 
     public ItemBlueprintBase? GetItemBlueprint(int id)
-    {
-        _itemBlueprints.TryGetValue(id, out var blueprint);
-        return blueprint;
-    }
+        => _itemBlueprints.GetValueOrDefault(id);
 
     public TBlueprint? GetItemBlueprint<TBlueprint>(int id)
         where TBlueprint : ItemBlueprintBase
@@ -81,13 +76,12 @@ public class ItemManager : IItemManager
 
     public void AddItemBlueprint(ItemBlueprintBase blueprint)
     {
-        if (_itemBlueprints.ContainsKey(blueprint.Id))
+        if (!_itemBlueprints.TryAdd(blueprint.Id, blueprint))
             Logger.LogError("Item blueprint duplicate {blueprintId}!!!", blueprint.Id);
         else
         {
             if (!FlagsManager.CheckFlags(blueprint.ItemFlags))
                 Logger.LogError("Item blueprint {blueprintId} has invalid flags", blueprint.Id);
-            _itemBlueprints.Add(blueprint.Id, blueprint);
         }
     }
 

--- a/Mud.Server/Item/ItemWeapon.cs
+++ b/Mud.Server/Item/ItemWeapon.cs
@@ -80,6 +80,8 @@ public class ItemWeapon : ItemBase, IItemWeapon
 
         // don't call base.Recompute because it would apply IItem aura and IItemAura would be applied again in ApplyAura<IItemWeapon>
         //base.Recompute();
+        // 0) Reset
+        ResetAttributesAndResourcesAndFlags();
 
         // 1/ Apply auras from room containing item if in a room
         if (ContainedInto is IRoom room && room.IsValid)

--- a/Mud.Server/Player/Player.cs
+++ b/Mud.Server/Player/Player.cs
@@ -12,6 +12,7 @@ using Mud.Server.Interfaces.Character;
 using Mud.Server.Interfaces.GameAction;
 using Mud.Server.Interfaces.Player;
 using System.Diagnostics;
+using System.Numerics;
 using System.Text;
 
 namespace Mud.Server.Player;
@@ -325,9 +326,9 @@ public class Player : ActorBase, IPlayer
     {
         Impersonating = avatar;
         PlayerState = PlayerStates.Impersonating;
-        StringBuilder sb = new();
-        avatar.Room.Append(sb, avatar);
-        avatar.Send(sb);
+        var result = GameActionManager.Execute<Commands.Character.Information.Look, ICharacter>(Impersonating, null);
+        if (result != null)
+            avatar.Send(result);
     }
 
     public void StopImpersonating()

--- a/Mud.Server/Room/Room.cs
+++ b/Mud.Server/Room/Room.cs
@@ -1,11 +1,12 @@
 ﻿using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Mud.Blueprints;
+using Mud.Blueprints.Character;
+using Mud.Blueprints.Room;
 using Mud.Common;
 using Mud.Common.Attributes;
 using Mud.DataStructures.Trie;
 using Mud.Domain;
-using Mud.Blueprints.Character;
-using Mud.Blueprints.Room;
 using Mud.Server.Common.Extensions;
 using Mud.Server.Common.Helpers;
 using Mud.Server.Domain;
@@ -138,7 +139,7 @@ public class Room : EntityBase, IRoom
 
     public RoomBlueprint Blueprint { get; private set; } = null!;
 
-    public ILookup<string, string> ExtraDescriptions => Blueprint.ExtraDescriptions;
+    public IEnumerable<ExtraDescription> ExtraDescriptions => Blueprint.ExtraDescriptions;
 
     public IRoomFlags BaseRoomFlags { get; protected set; } = null!;
     public IRoomFlags RoomFlags { get; protected set; } = null!;

--- a/Mud.Server/Room/RoomManager.cs
+++ b/Mud.Server/Room/RoomManager.cs
@@ -1,14 +1,12 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Mud.Blueprints.Room;
 using Mud.Common.Attributes;
 using Mud.Domain;
-using Mud.Blueprints.Room;
-using Mud.Server.Flags;
 using Mud.Server.Flags.Interfaces;
 using Mud.Server.Interfaces.Area;
 using Mud.Server.Interfaces.Character;
-using Mud.Server.Interfaces.Item;
 using Mud.Server.Interfaces.Room;
 using Mud.Server.Options;
 using Mud.Server.Random;
@@ -56,20 +54,16 @@ public class RoomManager : IRoomManager
         => _roomBlueprints.Values.ToList().AsReadOnly();
 
     public RoomBlueprint? GetRoomBlueprint(int id)
-    {
-        _roomBlueprints.TryGetValue(id, out var blueprint);
-        return blueprint;
-    }
+        => _roomBlueprints.GetValueOrDefault(id);
 
     public void AddRoomBlueprint(RoomBlueprint blueprint)
     {
-        if (_roomBlueprints.ContainsKey(blueprint.Id))
+        if (!_roomBlueprints.TryAdd(blueprint.Id, blueprint))
             Logger.LogError("Room blueprint duplicate {blueprintId}!!!", blueprint.Id);
         else
         {
             if (!FlagsManager.CheckFlags(blueprint.RoomFlags))
                 Logger.LogError("Room blueprint {blueprintId} has invalid flags", blueprint.Id);
-            _roomBlueprints.Add(blueprint.Id, blueprint);
         }
     }
 

--- a/TODO.txt
+++ b/TODO.txt
@@ -1,18 +1,27 @@
 INGOING
 DONE
-    SafeLinkedList implementation
+    WeaponFlags were not cleared correctly when worn off
+    Look item were missing CRLF when no extra description
+    ExtraDescription fixed (they were duplicated for each keyword)
+    Red Aura and Yellow Aura fixed (it's not displayed on target if evil/detect evil and good/detect good)
+    new data structure ArrayByEnum to avoid casting enum to int to access an array based on enum
+    fix inventory and equipment when blind (cannot see anything except potions)
+    call Look command when impersonating instead of calling directly room.display
+    optimize AbilityManager Search methods using Dictionary of Trie
+    new Dictionary extension method: GetOrDefaultValue
 
 ==========
 == TODO ==
 ==========
 
-Use SafeList where List is used (everywhere except in XXXManager)
+use SafeList where List is used (everywhere except in XXXManager)
 
 use resource cost for 'holy word': cost of 100% move and half hp
 
 due to new AbilityLearned (cost/amount/resource removed), an ability cannot be added if not related to current class/race
     we should be able to add ability to a character even if not related to current class/race (for immortal for example)
     -> must artificially create an AbilityUsage for that purpose
+    in fact, it's recompute known abilities which mess up learned abilities in pfile because it only considers racial abilities and abilities in learned groups
 
 new combat system
     how to handle mob assist ?(ASSIST_PLAYER, ASSIST_RACE, ASSIST_ALIGN, ASSIST_VNUM, ASSIST_GROUP)
@@ -20,6 +29,7 @@ new combat system
     kill reward
         first group to hit the mob will receive the reward
         if everyone in the group has been killed, reward priority goes to next group which has hit the mob
+        prevent kill stealing: a player fights a mob, brings it to 1% and another player performs killing blow (using mob.Fighting)
     threat/aggro (see Generating Threat)
     https://www.wowhead.com/classic/guide/threat-overview-classic-wow
 
@@ -120,7 +130,6 @@ admin commands: sockets, exlist, vlist, rename, omatch, mmatch, spy, violate, al
 	teleport, mwhere, owhere, recho, mset, oset, rset, sset, xstat, string, vnum, zecho, clone, smote, prefix, olevel, mlevel, slookup, clans, guild, confiscate/grab, 
 PK+THIEF
 furniture max weight (doesn't exist in Rom)
-prevent kill stealing: a player fights a mob, brings it to 1% and another player performs killing blow (using mob.Fighting)
 linkdead
 Move CanSee in IEntity
 each time operator IS or AS is used, this should be replaced with an overridable method
@@ -131,7 +140,6 @@ Monitor Recompute calls: recompute may leads to recursive call -> redo logic Une
 Create item from blueprint with specific level and attributes (used for SpellFloatingDisc and other skill/spell creating item)
 UnitTests on Rom24Effects
 assist_guard
-aggro table
 isValid on aura/periodic aura -> don't remove immediately aura/periodic aura + filter on isValid + remove them during Cleanup phease (--> no more clone of auras needed while modifying/clearing auras, same goes with periodic aura)
 leaving impersonation should not stop fighting -> PlayableCharacter can still died while not impersonated
   when impersonating, first search for impersonation in world -> use Guid !! should work if player disconnect/reconnect and reimpersonate


### PR DESCRIPTION
    WeaponFlags were not cleared correctly when worn off
    Look item were missing CRLF when no extra description
    ExtraDescription fixed (they were duplicated for each keyword)
    Red Aura and Yellow Aura fixed (it's not displayed on target if evil/detect evil and good/detect good)
    new data structure ArrayByEnum to avoid casting enum to int to access an array based on enum
    fix inventory and equipment when blind (cannot see anything except potions)
    call Look command when impersonating instead of calling directly room.display
    optimize AbilityManager Search methods using Dictionary of Trie
    new Dictionary extension method: GetOrDefaultValue
close #227 