### PR TITLE
#307

### DIFF
--- a/Apps/Mud.WPFTestApplication/ServerWindow.xaml.cs
+++ b/Apps/Mud.WPFTestApplication/ServerWindow.xaml.cs
@@ -12,9 +12,13 @@ using Mud.Flags;
 using Mud.Importer;
 using Mud.Network.Interfaces;
 using Mud.Random;
+using Mud.Server.Affects.Character;
+using Mud.Server.Aura;
 using Mud.Server.Interfaces;
 using Mud.Server.Interfaces.Admin;
+using Mud.Server.Interfaces.Affect.Character;
 using Mud.Server.Interfaces.Area;
+using Mud.Server.Interfaces.Aura;
 using Mud.Server.Interfaces.Character;
 using Mud.Server.Interfaces.Item;
 using Mud.Server.Interfaces.Player;
@@ -22,6 +26,7 @@ using Mud.Server.Interfaces.Quest;
 using Mud.Server.Interfaces.Room;
 using Mud.Server.Loot.Interfaces;
 using Mud.Server.Options;
+using Mud.Server.Race.Interfaces;
 using Mud.WPFTestApplication;
 using System;
 using System.Collections.Generic;
@@ -835,5 +840,56 @@ public partial class ServerWindow : Window, INetworkServer
         // hassan will generate random loot
         var hassanBlueprint = CharacterManager.GetCharacterBlueprint<CharacterBlueprintBase>(3011);
         hassanBlueprint.ActFlags.Set("RandomLoot");
+
+        //
+        var auraManager = ServiceProvider.GetRequiredService<IAuraManager>();
+
+        // add item with add insectoid race affect
+        var insectoidBeltBlueprint = new ItemArmorBlueprint
+        {
+            Id = 95,
+            Name = "belt insectoid",
+            ShortDescription = "an insectoid belt",
+            Description = "an insectoid belt is here",
+            WearLocation = WearLocations.Waist,
+            Level = 1,
+            Cost = 1,
+            NoTake = false,
+            ItemFlags = new ItemFlags(),
+            Bash = 0,
+            Pierce = 0,
+            Slash = 0,
+            Exotic = 0,
+            Weight = 10
+        };
+        ItemManager.AddItemBlueprint(insectoidBeltBlueprint);
+        var insectoidBelt = ItemManager.AddItem(Guid.NewGuid(), 95, "Test", onTheBridge); // 3051
+        var insectoidCharacterRaceAffect = ServiceProvider.GetRequiredService<CharacterRaceAffect>();
+        insectoidCharacterRaceAffect.Race = ServiceProvider.GetRequiredService<IRaceManager>()["insectoid"];
+        auraManager.AddAura(insectoidBelt, insectoidBelt, 1, new AuraFlags("permanent", "inherent"), false, insectoidCharacterRaceAffect);
+
+        // add item with add elf race affect
+        var elfBeltBlueprint = new ItemArmorBlueprint
+        {
+            Id = 94,
+            Name = "belt elf",
+            ShortDescription = "a elf belt",
+            Description = "an elf belt is here",
+            WearLocation = WearLocations.Waist,
+            Level = 1,
+            Cost = 1,
+            NoTake = false,
+            ItemFlags = new ItemFlags(),
+            Bash = 0,
+            Pierce = 0,
+            Slash = 0,
+            Exotic = 0,
+            Weight = 10
+        };
+        ItemManager.AddItemBlueprint(elfBeltBlueprint);
+        var elfBelt = ItemManager.AddItem(Guid.NewGuid(), 94, "Test", onTheBridge); // 3051
+        var elfCharacterRaceAffect = ServiceProvider.GetRequiredService<CharacterRaceAffect>();
+        elfCharacterRaceAffect.Race = ServiceProvider.GetRequiredService<IRaceManager>()["elf"];
+        auraManager.AddAura(elfBelt, elfBelt, 1, new AuraFlags("permanent", "inherent"), false, elfCharacterRaceAffect);
     }
 }

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,6 @@
+2026/02/13
+	- base/current race + race/body parts/body forms affect + doppleganger (#307)
+	- bug fixed in ApplyAffect(ICharacterIRVAffect affect) vulnerabilities affects were applied on resistances instead of vulnerabilities
 2026/02/07
     - Multiple managers fixed to used StringComparer.InvariantCultureIgnoreCase in dictionary (#305)
     - Floating disc fixed (#305)

--- a/Datas/Accounts/sinac.json
+++ b/Datas/Accounts/sinac.json
@@ -40,8 +40,8 @@
       "Classes": [
         "Warrior"
       ],
-      "Race": "Giant",
-      "RoomId": 9022
+      "Race": "Doppleganger",
+      "RoomId": 3051
     }
   ]
 }

--- a/Datas/Avatars/fnar.json
+++ b/Datas/Avatars/fnar.json
@@ -2,7 +2,7 @@
   "Version": 1,
   "AccountName": "sinac",
   "CreationTime": "2025-12-07T00:41:18.0014667+01:00",
-  "RoomId": 9022,
+  "RoomId": 3051,
   "SilverCoins": 10776876,
   "GoldCoins": 6069,
   "Wimpy": 0,
@@ -16,6 +16,24 @@
   },
   "ActiveQuests": [],
   "LearnedAbilities": [
+    {
+      "Name": "bash",
+      "Level": 1,
+      "Learned": 100,
+      "Rating": 1
+    },
+    {
+      "Name": "fast healing",
+      "Level": 1,
+      "Learned": 100,
+      "Rating": 1
+    },
+    {
+      "Name": "morph",
+      "Level": 1,
+      "Learned": 100,
+      "Rating": 0
+    },
     {
       "Name": "sword",
       "Level": 1,
@@ -57,12 +75,6 @@
       "Level": 1,
       "Learned": 88,
       "Rating": 2
-    },
-    {
-      "Name": "bash",
-      "Level": 1,
-      "Learned": 100,
-      "Rating": 1
     },
     {
       "Name": "disarm",
@@ -135,12 +147,6 @@
       "Level": 1,
       "Learned": 1,
       "Rating": 4
-    },
-    {
-      "Name": "fast healing",
-      "Level": 1,
-      "Learned": 100,
-      "Rating": 1
     },
     {
       "Name": "acid blast",
@@ -429,6 +435,24 @@
       "Level": 22,
       "Learned": 75,
       "Rating": 2
+    },
+    {
+      "Name": "dual wield",
+      "Level": 1,
+      "Learned": 100,
+      "Rating": 1
+    },
+    {
+      "Name": "third wield",
+      "Level": 1,
+      "Learned": 100,
+      "Rating": 1
+    },
+    {
+      "Name": "fourth wield",
+      "Level": 1,
+      "Learned": 100,
+      "Rating": 1
     }
   ],
   "LearnedAbilityGroups": [
@@ -475,9 +499,9 @@
   ],
   "Conditions": {
     "Drunk": 0,
-    "Full": 40,
-    "Thirst": 46,
-    "Hunger": 46
+    "Full": 36,
+    "Thirst": 45,
+    "Hunger": 44
   },
   "Aliases": {
     "a": "cast \u0027colour spray\u0027",
@@ -495,7 +519,7 @@
       "Sex": "Neutral",
       "Size": "Medium",
       "CurrentResources": {
-        "HitPoints": 38,
+        "HitPoints": 58,
         "MovePoints": 100,
         "Mana": 100,
         "Psy": 0,
@@ -569,7 +593,7 @@
       "Sex": "Neutral",
       "Size": "Tiny",
       "CurrentResources": {
-        "HitPoints": 2522,
+        "HitPoints": 2558,
         "MovePoints": 100,
         "Mana": 0,
         "Psy": 0,
@@ -690,7 +714,7 @@
   ],
   "PulseLeftBeforeNextAutomaticQuest": 0,
   "Name": "fnar",
-  "Race": "giant",
+  "Race": "doppleganger",
   "Classes": [
     "warrior"
   ],
@@ -698,17 +722,17 @@
   "Sex": "Male",
   "Size": "Large",
   "CurrentResources": {
-    "HitPoints": 427,
-    "MovePoints": 453,
-    "Mana": 259,
+    "HitPoints": 447,
+    "MovePoints": 475,
+    "Mana": 268,
     "Psy": 100,
     "Energy": 0,
     "Rage": 0,
     "Combo": 0
   },
   "MaxResources": {
-    "HitPoints": 581,
-    "MovePoints": 453,
+    "HitPoints": 589,
+    "MovePoints": 493,
     "Mana": 310,
     "Psy": 100,
     "Energy": 0,
@@ -1008,6 +1032,40 @@
       "Slot": "Hands",
       "Item": {
         "$type": "armor",
+        "Bash": 3,
+        "Pierce": 4,
+        "Slash": 4,
+        "Exotic": 0,
+        "ItemId": 2109,
+        "Source": "Oload[sinac]",
+        "ShortDescription": "comfortable leather gloves",
+        "Description": "A pair of soft lined leather gloves lie here.",
+        "Level": 7,
+        "Cost": 1010,
+        "DecayPulseLeft": 0,
+        "ItemFlags": "",
+        "Auras": [
+          {
+            "AbilityName": "",
+            "Level": 7,
+            "PulseLeft": -1,
+            "AuraFlags": "NoDispel,Permanent,Inherent",
+            "Affects": [
+              {
+                "$type": "characterAttribute",
+                "Operator": "Add",
+                "Location": "Strength",
+                "Modifier": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Slot": "Hands",
+      "Item": {
+        "$type": "armor",
         "Bash": 5,
         "Pierce": 5,
         "Slash": 5,
@@ -1032,6 +1090,41 @@
                 "Operator": "Add",
                 "Location": "Strength",
                 "Modifier": 2
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Slot": "Ring",
+      "Item": {
+        "ItemId": 3413,
+        "Source": "Reset-P[3434]",
+        "ShortDescription": "a black marble ring",
+        "Description": "A black marble ring is lying here on the ground.",
+        "Level": 3,
+        "Cost": 26,
+        "DecayPulseLeft": 0,
+        "ItemFlags": "Magic,AntiEvil",
+        "Auras": [
+          {
+            "AbilityName": "",
+            "Level": 3,
+            "PulseLeft": -1,
+            "AuraFlags": "NoDispel,Permanent,Inherent",
+            "Affects": [
+              {
+                "$type": "characterAttribute",
+                "Operator": "Add",
+                "Location": "SavingThrow",
+                "Modifier": 1
+              },
+              {
+                "$type": "characterResource",
+                "Operator": "Add",
+                "Location": "MovePoints",
+                "Modifier": 10
               }
             ]
           }
@@ -1145,20 +1238,20 @@
       "Item": {
         "$type": "weapon",
         "WeaponFlags": "",
-        "DiceCount": 3,
+        "DiceCount": 2,
         "DiceValue": 6,
-        "ItemId": 5105,
-        "Source": "Reset-E[5101]",
-        "ShortDescription": "a black longsword",
-        "Description": "A black longsword has been carelessly left here.",
-        "Level": 21,
-        "Cost": 2100,
+        "ItemId": 5100,
+        "Source": "Reset-E[5133]",
+        "ShortDescription": "a commoner\u0027s longsword",
+        "Description": "A commoner\u0027s longsword made of adamantite has been left here.",
+        "Level": 11,
+        "Cost": 910,
         "DecayPulseLeft": 0,
-        "ItemFlags": "Glowing,Magic",
+        "ItemFlags": "",
         "Auras": [
           {
             "AbilityName": "",
-            "Level": 21,
+            "Level": 11,
             "PulseLeft": -1,
             "AuraFlags": "NoDispel,Permanent,Inherent",
             "Affects": [
@@ -1166,13 +1259,52 @@
                 "$type": "characterAttribute",
                 "Operator": "Add",
                 "Location": "DamRoll",
-                "Modifier": 2
+                "Modifier": 1
               },
               {
                 "$type": "characterAttribute",
                 "Operator": "Add",
                 "Location": "HitRoll",
-                "Modifier": 2
+                "Modifier": 1
+              }
+            ]
+          }
+        ]
+      }
+    },
+    {
+      "Slot": "MainHand",
+      "Item": {
+        "$type": "weapon",
+        "WeaponFlags": "",
+        "DiceCount": 2,
+        "DiceValue": 6,
+        "ItemId": 5100,
+        "Source": "Reset-E[5133]",
+        "ShortDescription": "a commoner\u0027s longsword",
+        "Description": "A commoner\u0027s longsword made of adamantite has been left here.",
+        "Level": 11,
+        "Cost": 910,
+        "DecayPulseLeft": 0,
+        "ItemFlags": "",
+        "Auras": [
+          {
+            "AbilityName": "",
+            "Level": 11,
+            "PulseLeft": -1,
+            "AuraFlags": "NoDispel,Permanent,Inherent",
+            "Affects": [
+              {
+                "$type": "characterAttribute",
+                "Operator": "Add",
+                "Location": "DamRoll",
+                "Modifier": 1
+              },
+              {
+                "$type": "characterAttribute",
+                "Operator": "Add",
+                "Location": "HitRoll",
+                "Modifier": 1
               }
             ]
           }
@@ -1182,40 +1314,99 @@
     {
       "Slot": "OffHand",
       "Item": {
-        "$type": "shield",
-        "Armor": 17,
-        "ItemId": 5320,
-        "Source": "Oload[sinac]",
-        "ShortDescription": "an imperial shield",
-        "Description": "You see an imperial shield here.",
-        "Level": 10,
-        "Cost": 1190,
+        "$type": "weapon",
+        "WeaponFlags": "",
+        "DiceCount": 2,
+        "DiceValue": 6,
+        "ItemId": 5100,
+        "Source": "Reset-E[5133]",
+        "ShortDescription": "a commoner\u0027s longsword",
+        "Description": "A commoner\u0027s longsword made of adamantite has been left here.",
+        "Level": 11,
+        "Cost": 910,
         "DecayPulseLeft": 0,
         "ItemFlags": "",
-        "Auras": []
+        "Auras": [
+          {
+            "AbilityName": "",
+            "Level": 11,
+            "PulseLeft": -1,
+            "AuraFlags": "NoDispel,Permanent,Inherent",
+            "Affects": [
+              {
+                "$type": "characterAttribute",
+                "Operator": "Add",
+                "Location": "DamRoll",
+                "Modifier": 1
+              },
+              {
+                "$type": "characterAttribute",
+                "Operator": "Add",
+                "Location": "HitRoll",
+                "Modifier": 1
+              }
+            ]
+          }
+        ]
       }
     },
     {
-      "Slot": "Float",
+      "Slot": "OffHand",
       "Item": {
-        "$type": "container",
-        "MaxWeight": 230,
-        "ContainerFlags": "NoClose,NoLock",
-        "MaxWeightPerItem": 115,
-        "Contains": [],
-        "ItemId": 23,
-        "Source": "SpellFloatingDisc[Fnar[Sinac][Id:296ebb7d-d57b-4cd7-87e5-94e4e98617a9]]",
-        "ShortDescription": "a floating disc",
-        "Description": "A floating black disc hangs in the air.",
-        "Level": 23,
-        "Cost": 0,
-        "DecayPulseLeft": 8400,
-        "ItemFlags": "Magic,NoRemove,RotDeath,MeltOnDrop,BurnProof,NoUncurse",
-        "Auras": []
+        "$type": "weapon",
+        "WeaponFlags": "",
+        "DiceCount": 3,
+        "DiceValue": 5,
+        "ItemId": 3350,
+        "Source": "Reset-E[3040]",
+        "ShortDescription": "a standard issue sword",
+        "Description": "You see a standard issue sword here.",
+        "Level": 16,
+        "Cost": 1280,
+        "DecayPulseLeft": 0,
+        "ItemFlags": "Magic",
+        "Auras": [
+          {
+            "AbilityName": "",
+            "Level": 16,
+            "PulseLeft": -1,
+            "AuraFlags": "NoDispel,Permanent,Inherent",
+            "Affects": [
+              {
+                "$type": "characterAttribute",
+                "Operator": "Add",
+                "Location": "DamRoll",
+                "Modifier": 1
+              },
+              {
+                "$type": "characterAttribute",
+                "Operator": "Add",
+                "Location": "HitRoll",
+                "Modifier": 1
+              }
+            ]
+          }
+        ]
       }
     }
   ],
   "Inventory": [
+    {
+      "$type": "container",
+      "MaxWeight": 230,
+      "ContainerFlags": "NoClose,NoLock",
+      "MaxWeightPerItem": 115,
+      "Contains": [],
+      "ItemId": 23,
+      "Source": "SpellFloatingDisc[Fnar[Sinac][Id:296ebb7d-d57b-4cd7-87e5-94e4e98617a9]]",
+      "ShortDescription": "a floating disc",
+      "Description": "A floating black disc hangs in the air.",
+      "Level": 23,
+      "Cost": 0,
+      "DecayPulseLeft": 8160,
+      "ItemFlags": "Magic,NoRemove,RotDeath,MeltOnDrop,BurnProof,NoUncurse",
+      "Auras": []
+    },
     {
       "$type": "corpse",
       "Contains": [],
@@ -1228,27 +1419,323 @@
       "Description": "The corpse of The quinton is lying here.",
       "Level": 0,
       "Cost": 0,
-      "DecayPulseLeft": 960,
+      "DecayPulseLeft": 720,
+      "ItemFlags": "",
+      "Auras": []
+    },
+    {
+      "$type": "wand",
+      "SpellLevel": 10,
+      "MaxChargeCount": 3,
+      "CurrentChargeCount": 3,
+      "AlreadyRecharged": false,
+      "ItemId": 5110,
+      "Source": "Reset-E[5120]",
+      "ShortDescription": "a silvery blue wand",
+      "Description": "A silvery blue wand has been dropped in the dirt.",
+      "Level": 9,
+      "Cost": 1550,
+      "DecayPulseLeft": 0,
+      "ItemFlags": "Magic",
+      "Auras": []
+    },
+    {
+      "ItemId": 3162,
+      "Source": null,
+      "ShortDescription": "a map of the city of Midgaard",
+      "Description": "a map of the city of Midgaard",
+      "Level": 0,
+      "Cost": 0,
+      "DecayPulseLeft": 0,
+      "ItemFlags": "",
+      "Auras": []
+    },
+    {
+      "ItemId": 3050,
+      "Source": "Buy[The captain[Id:3006]]",
+      "ShortDescription": "a raft",
+      "Description": "A raft has been left here.",
+      "Level": 0,
+      "Cost": 400,
+      "DecayPulseLeft": 0,
+      "ItemFlags": "",
+      "Auras": []
+    },
+    {
+      "$type": "wand",
+      "SpellLevel": 30,
+      "MaxChargeCount": 10,
+      "CurrentChargeCount": 10,
+      "AlreadyRecharged": false,
+      "ItemId": 5020,
+      "Source": "Reset-G[5028]",
+      "ShortDescription": "a platinum wand",
+      "Description": "A platinum wand lies here.",
+      "Level": 2,
+      "Cost": 990,
+      "DecayPulseLeft": 0,
+      "ItemFlags": "Humming",
+      "Auras": []
+    },
+    {
+      "$type": "wand",
+      "SpellLevel": 30,
+      "MaxChargeCount": 10,
+      "CurrentChargeCount": 10,
+      "AlreadyRecharged": false,
+      "ItemId": 5020,
+      "Source": "Reset-G[5028]",
+      "ShortDescription": "a platinum wand",
+      "Description": "A platinum wand lies here.",
+      "Level": 2,
+      "Cost": 990,
+      "DecayPulseLeft": 0,
+      "ItemFlags": "Humming",
+      "Auras": []
+    },
+    {
+      "$type": "potion",
+      "SpellLevel": 25,
+      "ItemId": 5019,
+      "Source": "Reset-G[5028]",
+      "ShortDescription": "a pink potion",
+      "Description": "A pink potion stands here.",
+      "Level": 13,
+      "Cost": 1220,
+      "DecayPulseLeft": 219120,
+      "ItemFlags": "",
+      "Auras": []
+    },
+    {
+      "$type": "wand",
+      "SpellLevel": 30,
+      "MaxChargeCount": 10,
+      "CurrentChargeCount": 10,
+      "AlreadyRecharged": false,
+      "ItemId": 5020,
+      "Source": "Reset-G[5028]",
+      "ShortDescription": "a platinum wand",
+      "Description": "A platinum wand lies here.",
+      "Level": 2,
+      "Cost": 990,
+      "DecayPulseLeft": 0,
+      "ItemFlags": "Humming",
+      "Auras": []
+    },
+    {
+      "$type": "potion",
+      "SpellLevel": 25,
+      "ItemId": 5019,
+      "Source": "Reset-G[5028]",
+      "ShortDescription": "a pink potion",
+      "Description": "A pink potion stands here.",
+      "Level": 13,
+      "Cost": 1220,
+      "DecayPulseLeft": 139200,
+      "ItemFlags": "",
+      "Auras": []
+    },
+    {
+      "$type": "wand",
+      "SpellLevel": 30,
+      "MaxChargeCount": 10,
+      "CurrentChargeCount": 10,
+      "AlreadyRecharged": false,
+      "ItemId": 5020,
+      "Source": "Reset-G[5028]",
+      "ShortDescription": "a platinum wand",
+      "Description": "A platinum wand lies here.",
+      "Level": 2,
+      "Cost": 990,
+      "DecayPulseLeft": 0,
+      "ItemFlags": "Humming",
+      "Auras": []
+    },
+    {
+      "$type": "wand",
+      "SpellLevel": 30,
+      "MaxChargeCount": 10,
+      "CurrentChargeCount": 10,
+      "AlreadyRecharged": false,
+      "ItemId": 5020,
+      "Source": "Reset-G[5028]",
+      "ShortDescription": "a platinum wand",
+      "Description": "A platinum wand lies here.",
+      "Level": 2,
+      "Cost": 990,
+      "DecayPulseLeft": 0,
+      "ItemFlags": "Humming",
+      "Auras": []
+    },
+    {
+      "$type": "potion",
+      "SpellLevel": 25,
+      "ItemId": 5019,
+      "Source": "Reset-G[5028]",
+      "ShortDescription": "a pink potion",
+      "Description": "A pink potion stands here.",
+      "Level": 13,
+      "Cost": 1220,
+      "DecayPulseLeft": 144480,
+      "ItemFlags": "",
+      "Auras": []
+    },
+    {
+      "$type": "potion",
+      "SpellLevel": 25,
+      "ItemId": 5019,
+      "Source": "Reset-G[5028]",
+      "ShortDescription": "a pink potion",
+      "Description": "A pink potion stands here.",
+      "Level": 13,
+      "Cost": 1220,
+      "DecayPulseLeft": 148560,
+      "ItemFlags": "",
+      "Auras": []
+    },
+    {
+      "$type": "food",
+      "FullHours": 20,
+      "HungerHours": 40,
+      "IsPoisoned": false,
+      "ItemId": 3009,
+      "Source": "Buy[The baker[Id:3001]]",
+      "ShortDescription": "a big pot pie",
+      "Description": "A big pot pie has been left here.",
+      "Level": 0,
+      "Cost": 22,
+      "DecayPulseLeft": 0,
+      "ItemFlags": "",
+      "Auras": []
+    },
+    {
+      "$type": "food",
+      "FullHours": 20,
+      "HungerHours": 40,
+      "IsPoisoned": false,
+      "ItemId": 3009,
+      "Source": "Buy[The baker[Id:3001]]",
+      "ShortDescription": "a big pot pie",
+      "Description": "A big pot pie has been left here.",
+      "Level": 0,
+      "Cost": 22,
+      "DecayPulseLeft": 0,
+      "ItemFlags": "",
+      "Auras": []
+    },
+    {
+      "ItemId": 3430,
+      "Source": "Reset-G[3405]",
+      "ShortDescription": "a silver key",
+      "Description": "You see a silver key here.",
+      "Level": 0,
+      "Cost": 0,
+      "DecayPulseLeft": 0,
+      "ItemFlags": "",
+      "Auras": []
+    },
+    {
+      "ItemId": 3416,
+      "Source": "Reset-E[3424]",
+      "ShortDescription": "a heavy iron key",
+      "Description": "A heavy iron key is lying here.",
+      "Level": 0,
+      "Cost": 0,
+      "DecayPulseLeft": 0,
+      "ItemFlags": "",
+      "Auras": []
+    },
+    {
+      "$type": "drinkContainer",
+      "MaxLiquidAmount": 30,
+      "CurrentLiquidAmount": 15,
+      "LiquidName": "red wine",
+      "IsPoisoned": false,
+      "ItemId": 3417,
+      "Source": "Reset-P[3424]",
+      "ShortDescription": "a wineflask",
+      "Description": "A wineflask has been been left here.",
+      "Level": 0,
+      "Cost": 400,
+      "DecayPulseLeft": 0,
+      "ItemFlags": "",
+      "Auras": []
+    },
+    {
+      "$type": "food",
+      "FullHours": 20,
+      "HungerHours": 40,
+      "IsPoisoned": false,
+      "ItemId": 3009,
+      "Source": "Buy[The baker[Id:3001]]",
+      "ShortDescription": "a big pot pie",
+      "Description": "A big pot pie has been left here.",
+      "Level": 0,
+      "Cost": 22,
+      "DecayPulseLeft": 0,
+      "ItemFlags": "",
+      "Auras": []
+    },
+    {
+      "$type": "food",
+      "FullHours": 20,
+      "HungerHours": 40,
+      "IsPoisoned": false,
+      "ItemId": 3009,
+      "Source": "Buy[The baker[Id:3001]]",
+      "ShortDescription": "a big pot pie",
+      "Description": "A big pot pie has been left here.",
+      "Level": 0,
+      "Cost": 22,
+      "DecayPulseLeft": 0,
+      "ItemFlags": "",
+      "Auras": []
+    },
+    {
+      "$type": "food",
+      "FullHours": 20,
+      "HungerHours": 40,
+      "IsPoisoned": false,
+      "ItemId": 3009,
+      "Source": "Buy[The baker[Id:3001]]",
+      "ShortDescription": "a big pot pie",
+      "Description": "A big pot pie has been left here.",
+      "Level": 0,
+      "Cost": 22,
+      "DecayPulseLeft": 0,
+      "ItemFlags": "",
+      "Auras": []
+    },
+    {
+      "$type": "shield",
+      "Armor": 17,
+      "ItemId": 5320,
+      "Source": "Oload[sinac]",
+      "ShortDescription": "an imperial shield",
+      "Description": "You see an imperial shield here.",
+      "Level": 10,
+      "Cost": 1190,
+      "DecayPulseLeft": 0,
       "ItemFlags": "",
       "Auras": []
     },
     {
       "$type": "weapon",
       "WeaponFlags": "",
-      "DiceCount": 2,
+      "DiceCount": 3,
       "DiceValue": 6,
-      "ItemId": 5100,
-      "Source": "Reset-E[5133]",
-      "ShortDescription": "a commoner\u0027s longsword",
-      "Description": "A commoner\u0027s longsword made of adamantite has been left here.",
-      "Level": 11,
-      "Cost": 910,
+      "ItemId": 5105,
+      "Source": "Reset-E[5101]",
+      "ShortDescription": "a black longsword",
+      "Description": "A black longsword has been carelessly left here.",
+      "Level": 21,
+      "Cost": 2100,
       "DecayPulseLeft": 0,
-      "ItemFlags": "",
+      "ItemFlags": "Glowing,Magic",
       "Auras": [
         {
           "AbilityName": "",
-          "Level": 11,
+          "Level": 21,
           "PulseLeft": -1,
           "AuraFlags": "NoDispel,Permanent,Inherent",
           "Affects": [
@@ -1256,44 +1743,13 @@
               "$type": "characterAttribute",
               "Operator": "Add",
               "Location": "DamRoll",
-              "Modifier": 1
+              "Modifier": 2
             },
             {
               "$type": "characterAttribute",
               "Operator": "Add",
               "Location": "HitRoll",
-              "Modifier": 1
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "$type": "armor",
-      "Bash": 3,
-      "Pierce": 4,
-      "Slash": 4,
-      "Exotic": 0,
-      "ItemId": 2109,
-      "Source": "Oload[sinac]",
-      "ShortDescription": "comfortable leather gloves",
-      "Description": "A pair of soft lined leather gloves lie here.",
-      "Level": 7,
-      "Cost": 1010,
-      "DecayPulseLeft": 0,
-      "ItemFlags": "",
-      "Auras": [
-        {
-          "AbilityName": "",
-          "Level": 7,
-          "PulseLeft": -1,
-          "AuraFlags": "NoDispel,Permanent,Inherent",
-          "Affects": [
-            {
-              "$type": "characterAttribute",
-              "Operator": "Add",
-              "Location": "Strength",
-              "Modifier": 1
+              "Modifier": 2
             }
           ]
         }
@@ -1442,436 +1898,13 @@
           ]
         }
       ]
-    },
-    {
-      "$type": "weapon",
-      "WeaponFlags": "",
-      "DiceCount": 2,
-      "DiceValue": 6,
-      "ItemId": 5100,
-      "Source": "Reset-E[5133]",
-      "ShortDescription": "a commoner\u0027s longsword",
-      "Description": "A commoner\u0027s longsword made of adamantite has been left here.",
-      "Level": 11,
-      "Cost": 910,
-      "DecayPulseLeft": 0,
-      "ItemFlags": "",
-      "Auras": [
-        {
-          "AbilityName": "",
-          "Level": 11,
-          "PulseLeft": -1,
-          "AuraFlags": "NoDispel,Permanent,Inherent",
-          "Affects": [
-            {
-              "$type": "characterAttribute",
-              "Operator": "Add",
-              "Location": "DamRoll",
-              "Modifier": 1
-            },
-            {
-              "$type": "characterAttribute",
-              "Operator": "Add",
-              "Location": "HitRoll",
-              "Modifier": 1
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "$type": "weapon",
-      "WeaponFlags": "",
-      "DiceCount": 2,
-      "DiceValue": 6,
-      "ItemId": 5100,
-      "Source": "Reset-E[5133]",
-      "ShortDescription": "a commoner\u0027s longsword",
-      "Description": "A commoner\u0027s longsword made of adamantite has been left here.",
-      "Level": 11,
-      "Cost": 910,
-      "DecayPulseLeft": 0,
-      "ItemFlags": "",
-      "Auras": [
-        {
-          "AbilityName": "",
-          "Level": 11,
-          "PulseLeft": -1,
-          "AuraFlags": "NoDispel,Permanent,Inherent",
-          "Affects": [
-            {
-              "$type": "characterAttribute",
-              "Operator": "Add",
-              "Location": "DamRoll",
-              "Modifier": 1
-            },
-            {
-              "$type": "characterAttribute",
-              "Operator": "Add",
-              "Location": "HitRoll",
-              "Modifier": 1
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "$type": "weapon",
-      "WeaponFlags": "",
-      "DiceCount": 3,
-      "DiceValue": 5,
-      "ItemId": 3350,
-      "Source": "Reset-E[3040]",
-      "ShortDescription": "a standard issue sword",
-      "Description": "You see a standard issue sword here.",
-      "Level": 16,
-      "Cost": 1280,
-      "DecayPulseLeft": 0,
-      "ItemFlags": "Magic",
-      "Auras": [
-        {
-          "AbilityName": "",
-          "Level": 16,
-          "PulseLeft": -1,
-          "AuraFlags": "NoDispel,Permanent,Inherent",
-          "Affects": [
-            {
-              "$type": "characterAttribute",
-              "Operator": "Add",
-              "Location": "DamRoll",
-              "Modifier": 1
-            },
-            {
-              "$type": "characterAttribute",
-              "Operator": "Add",
-              "Location": "HitRoll",
-              "Modifier": 1
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "$type": "wand",
-      "SpellLevel": 10,
-      "MaxChargeCount": 3,
-      "CurrentChargeCount": 3,
-      "AlreadyRecharged": false,
-      "ItemId": 5110,
-      "Source": "Reset-E[5120]",
-      "ShortDescription": "a silvery blue wand",
-      "Description": "A silvery blue wand has been dropped in the dirt.",
-      "Level": 9,
-      "Cost": 1550,
-      "DecayPulseLeft": 0,
-      "ItemFlags": "Magic",
-      "Auras": []
-    },
-    {
-      "ItemId": 3162,
-      "Source": null,
-      "ShortDescription": "a map of the city of Midgaard",
-      "Description": "a map of the city of Midgaard",
-      "Level": 0,
-      "Cost": 0,
-      "DecayPulseLeft": 0,
-      "ItemFlags": "",
-      "Auras": []
-    },
-    {
-      "ItemId": 3050,
-      "Source": "Buy[The captain[Id:3006]]",
-      "ShortDescription": "a raft",
-      "Description": "A raft has been left here.",
-      "Level": 0,
-      "Cost": 400,
-      "DecayPulseLeft": 0,
-      "ItemFlags": "",
-      "Auras": []
-    },
-    {
-      "$type": "wand",
-      "SpellLevel": 30,
-      "MaxChargeCount": 10,
-      "CurrentChargeCount": 10,
-      "AlreadyRecharged": false,
-      "ItemId": 5020,
-      "Source": "Reset-G[5028]",
-      "ShortDescription": "a platinum wand",
-      "Description": "A platinum wand lies here.",
-      "Level": 2,
-      "Cost": 990,
-      "DecayPulseLeft": 0,
-      "ItemFlags": "Humming",
-      "Auras": []
-    },
-    {
-      "$type": "wand",
-      "SpellLevel": 30,
-      "MaxChargeCount": 10,
-      "CurrentChargeCount": 10,
-      "AlreadyRecharged": false,
-      "ItemId": 5020,
-      "Source": "Reset-G[5028]",
-      "ShortDescription": "a platinum wand",
-      "Description": "A platinum wand lies here.",
-      "Level": 2,
-      "Cost": 990,
-      "DecayPulseLeft": 0,
-      "ItemFlags": "Humming",
-      "Auras": []
-    },
-    {
-      "$type": "potion",
-      "SpellLevel": 25,
-      "ItemId": 5019,
-      "Source": "Reset-G[5028]",
-      "ShortDescription": "a pink potion",
-      "Description": "A pink potion stands here.",
-      "Level": 13,
-      "Cost": 1220,
-      "DecayPulseLeft": 219360,
-      "ItemFlags": "",
-      "Auras": []
-    },
-    {
-      "$type": "wand",
-      "SpellLevel": 30,
-      "MaxChargeCount": 10,
-      "CurrentChargeCount": 10,
-      "AlreadyRecharged": false,
-      "ItemId": 5020,
-      "Source": "Reset-G[5028]",
-      "ShortDescription": "a platinum wand",
-      "Description": "A platinum wand lies here.",
-      "Level": 2,
-      "Cost": 990,
-      "DecayPulseLeft": 0,
-      "ItemFlags": "Humming",
-      "Auras": []
-    },
-    {
-      "$type": "potion",
-      "SpellLevel": 25,
-      "ItemId": 5019,
-      "Source": "Reset-G[5028]",
-      "ShortDescription": "a pink potion",
-      "Description": "A pink potion stands here.",
-      "Level": 13,
-      "Cost": 1220,
-      "DecayPulseLeft": 139440,
-      "ItemFlags": "",
-      "Auras": []
-    },
-    {
-      "$type": "wand",
-      "SpellLevel": 30,
-      "MaxChargeCount": 10,
-      "CurrentChargeCount": 10,
-      "AlreadyRecharged": false,
-      "ItemId": 5020,
-      "Source": "Reset-G[5028]",
-      "ShortDescription": "a platinum wand",
-      "Description": "A platinum wand lies here.",
-      "Level": 2,
-      "Cost": 990,
-      "DecayPulseLeft": 0,
-      "ItemFlags": "Humming",
-      "Auras": []
-    },
-    {
-      "$type": "wand",
-      "SpellLevel": 30,
-      "MaxChargeCount": 10,
-      "CurrentChargeCount": 10,
-      "AlreadyRecharged": false,
-      "ItemId": 5020,
-      "Source": "Reset-G[5028]",
-      "ShortDescription": "a platinum wand",
-      "Description": "A platinum wand lies here.",
-      "Level": 2,
-      "Cost": 990,
-      "DecayPulseLeft": 0,
-      "ItemFlags": "Humming",
-      "Auras": []
-    },
-    {
-      "$type": "potion",
-      "SpellLevel": 25,
-      "ItemId": 5019,
-      "Source": "Reset-G[5028]",
-      "ShortDescription": "a pink potion",
-      "Description": "A pink potion stands here.",
-      "Level": 13,
-      "Cost": 1220,
-      "DecayPulseLeft": 144720,
-      "ItemFlags": "",
-      "Auras": []
-    },
-    {
-      "$type": "potion",
-      "SpellLevel": 25,
-      "ItemId": 5019,
-      "Source": "Reset-G[5028]",
-      "ShortDescription": "a pink potion",
-      "Description": "A pink potion stands here.",
-      "Level": 13,
-      "Cost": 1220,
-      "DecayPulseLeft": 148800,
-      "ItemFlags": "",
-      "Auras": []
-    },
-    {
-      "$type": "food",
-      "FullHours": 20,
-      "HungerHours": 40,
-      "IsPoisoned": false,
-      "ItemId": 3009,
-      "Source": "Buy[The baker[Id:3001]]",
-      "ShortDescription": "a big pot pie",
-      "Description": "A big pot pie has been left here.",
-      "Level": 0,
-      "Cost": 22,
-      "DecayPulseLeft": 0,
-      "ItemFlags": "",
-      "Auras": []
-    },
-    {
-      "$type": "food",
-      "FullHours": 20,
-      "HungerHours": 40,
-      "IsPoisoned": false,
-      "ItemId": 3009,
-      "Source": "Buy[The baker[Id:3001]]",
-      "ShortDescription": "a big pot pie",
-      "Description": "A big pot pie has been left here.",
-      "Level": 0,
-      "Cost": 22,
-      "DecayPulseLeft": 0,
-      "ItemFlags": "",
-      "Auras": []
-    },
-    {
-      "ItemId": 3430,
-      "Source": "Reset-G[3405]",
-      "ShortDescription": "a silver key",
-      "Description": "You see a silver key here.",
-      "Level": 0,
-      "Cost": 0,
-      "DecayPulseLeft": 0,
-      "ItemFlags": "",
-      "Auras": []
-    },
-    {
-      "ItemId": 3416,
-      "Source": "Reset-E[3424]",
-      "ShortDescription": "a heavy iron key",
-      "Description": "A heavy iron key is lying here.",
-      "Level": 0,
-      "Cost": 0,
-      "DecayPulseLeft": 0,
-      "ItemFlags": "",
-      "Auras": []
-    },
-    {
-      "$type": "drinkContainer",
-      "MaxLiquidAmount": 30,
-      "CurrentLiquidAmount": 15,
-      "LiquidName": "red wine",
-      "IsPoisoned": false,
-      "ItemId": 3417,
-      "Source": "Reset-P[3424]",
-      "ShortDescription": "a wineflask",
-      "Description": "A wineflask has been been left here.",
-      "Level": 0,
-      "Cost": 400,
-      "DecayPulseLeft": 0,
-      "ItemFlags": "",
-      "Auras": []
-    },
-    {
-      "ItemId": 3413,
-      "Source": "Reset-P[3434]",
-      "ShortDescription": "a black marble ring",
-      "Description": "A black marble ring is lying here on the ground.",
-      "Level": 3,
-      "Cost": 26,
-      "DecayPulseLeft": 0,
-      "ItemFlags": "Magic,AntiEvil",
-      "Auras": [
-        {
-          "AbilityName": "",
-          "Level": 3,
-          "PulseLeft": -1,
-          "AuraFlags": "NoDispel,Permanent,Inherent",
-          "Affects": [
-            {
-              "$type": "characterAttribute",
-              "Operator": "Add",
-              "Location": "SavingThrow",
-              "Modifier": 1
-            },
-            {
-              "$type": "characterResource",
-              "Operator": "Add",
-              "Location": "MovePoints",
-              "Modifier": 10
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "$type": "food",
-      "FullHours": 20,
-      "HungerHours": 40,
-      "IsPoisoned": false,
-      "ItemId": 3009,
-      "Source": "Buy[The baker[Id:3001]]",
-      "ShortDescription": "a big pot pie",
-      "Description": "A big pot pie has been left here.",
-      "Level": 0,
-      "Cost": 22,
-      "DecayPulseLeft": 0,
-      "ItemFlags": "",
-      "Auras": []
-    },
-    {
-      "$type": "food",
-      "FullHours": 20,
-      "HungerHours": 40,
-      "IsPoisoned": false,
-      "ItemId": 3009,
-      "Source": "Buy[The baker[Id:3001]]",
-      "ShortDescription": "a big pot pie",
-      "Description": "A big pot pie has been left here.",
-      "Level": 0,
-      "Cost": 22,
-      "DecayPulseLeft": 0,
-      "ItemFlags": "",
-      "Auras": []
-    },
-    {
-      "$type": "food",
-      "FullHours": 20,
-      "HungerHours": 40,
-      "IsPoisoned": false,
-      "ItemId": 3009,
-      "Source": "Buy[The baker[Id:3001]]",
-      "ShortDescription": "a big pot pie",
-      "Description": "A big pot pie has been left here.",
-      "Level": 0,
-      "Cost": 22,
-      "DecayPulseLeft": 0,
-      "ItemFlags": "",
-      "Auras": []
     }
   ],
   "Auras": [
     {
       "AbilityName": "armor",
-      "Level": 23,
-      "PulseLeft": 5200,
+      "Level": 22,
+      "PulseLeft": 4792,
       "AuraFlags": "",
       "Affects": [
         {
@@ -1885,7 +1918,7 @@
     {
       "AbilityName": "bless",
       "Level": 23,
-      "PulseLeft": 6408,
+      "PulseLeft": 6000,
       "AuraFlags": "",
       "Affects": [
         {
@@ -1905,7 +1938,7 @@
     {
       "AbilityName": "fly",
       "Level": 23,
-      "PulseLeft": 5708,
+      "PulseLeft": 5300,
       "AuraFlags": "",
       "Affects": [
         {
@@ -1918,7 +1951,7 @@
     {
       "AbilityName": "protection evil",
       "Level": 23,
-      "PulseLeft": 5244,
+      "PulseLeft": 4836,
       "AuraFlags": "",
       "Affects": [
         {
@@ -1941,7 +1974,7 @@
     {
       "AbilityName": "giant strength",
       "Level": 24,
-      "PulseLeft": 5752,
+      "PulseLeft": 5344,
       "AuraFlags": "",
       "Affects": [
         {
@@ -1951,12 +1984,61 @@
           "Modifier": 2
         }
       ]
+    },
+    {
+      "AbilityName": "morph",
+      "Level": 24,
+      "PulseLeft": -1,
+      "AuraFlags": "NoDispel,Permanent,Shapeshift",
+      "Affects": [
+        {
+          "$type": "race",
+          "Race": "insectoid"
+        },
+        {
+          "$type": "size",
+          "Value": "Medium"
+        },
+        {
+          "$type": "characterFlags",
+          "Operator": "Assign",
+          "Modifier": ""
+        },
+        {
+          "$type": "irv",
+          "Location": "Immunities",
+          "Operator": "Assign",
+          "Modifier": ""
+        },
+        {
+          "$type": "irv",
+          "Location": "Resistances",
+          "Operator": "Assign",
+          "Modifier": "Bash,Slash,Poison,Disease,Acid"
+        },
+        {
+          "$type": "irv",
+          "Location": "Vulnerabilities",
+          "Operator": "Assign",
+          "Modifier": "Pierce,Fire,Cold"
+        },
+        {
+          "$type": "bodyForms",
+          "Operator": "Assign",
+          "Modifier": "magical,sentient"
+        },
+        {
+          "$type": "bodyParts",
+          "Operator": "Assign",
+          "Modifier": ""
+        }
+      ]
     }
   ],
   "CharacterFlags": "",
   "Immunities": "",
-  "Resistances": "Fire,Cold",
-  "Vulnerabilities": "Mental,Lightning",
+  "Resistances": "",
+  "Vulnerabilities": "",
   "ShieldFlags": "",
   "Attributes": {
     "Strength": 24,

--- a/Server/Mud.Server.Ability.Skill/NoTargetSkillBase.cs
+++ b/Server/Mud.Server.Ability.Skill/NoTargetSkillBase.cs
@@ -15,6 +15,6 @@ public abstract class NoTargetSkillBase : SkillBase
 
     protected override IGuard<ICharacter>[] Guards => [];
 
-    protected override string SetTargets(ISkillActionInput skillActionInput)
+    protected override string? SetTargets(ISkillActionInput skillActionInput)
         => null!;
 }

--- a/Server/Mud.Server.Affects/Character/CharacterBodyFormsAffect.cs
+++ b/Server/Mud.Server.Affects/Character/CharacterBodyFormsAffect.cs
@@ -1,0 +1,34 @@
+﻿using Mud.Domain.SerializationData.Avatar;
+using Mud.Flags;
+using Mud.Flags.Interfaces;
+using Mud.Server.Domain.Attributes;
+using Mud.Server.Interfaces.Affect.Character;
+using Mud.Server.Interfaces.Character;
+
+namespace Mud.Server.Affects.Character;
+
+[Affect("CharacterBodyFormsAffect", typeof(CharacterBodyFormsAffectData))]
+public class CharacterBodyFormsAffect : FlagsAffectBase<IBodyForms>, ICharacterBodyFormsAffect
+{
+    protected override string Target => "Body forms";
+
+    public void Initialize(CharacterBodyFormsAffectData data)
+    {
+        Operator = data.Operator;
+        Modifier = new BodyForms(data.Modifier);
+    }
+
+    public void Apply(ICharacter character)
+    {
+        character.ApplyAffect(this);
+    }
+
+    public override AffectDataBase MapAffectData()
+    {
+        return new CharacterBodyFormsAffectData
+        {
+            Operator = Operator,
+            Modifier = Modifier.Serialize()
+        };
+    }
+}

--- a/Server/Mud.Server.Affects/Character/CharacterBodyFormsAffectData.cs
+++ b/Server/Mud.Server.Affects/Character/CharacterBodyFormsAffectData.cs
@@ -1,0 +1,13 @@
+﻿using Mud.Common.Attributes;
+using Mud.Domain.SerializationData.Avatar;
+using Mud.Server.Domain;
+
+namespace Mud.Server.Affects.Character;
+
+[JsonBaseType(typeof(AffectDataBase), "bodyForms")]
+public class CharacterBodyFormsAffectData : AffectDataBase
+{
+    public required AffectOperators Operator { get; set; } // Add and Or are identical
+
+    public required string Modifier { get; set; }
+}

--- a/Server/Mud.Server.Affects/Character/CharacterBodyPartsAffect.cs
+++ b/Server/Mud.Server.Affects/Character/CharacterBodyPartsAffect.cs
@@ -1,0 +1,34 @@
+﻿using Mud.Domain.SerializationData.Avatar;
+using Mud.Flags;
+using Mud.Flags.Interfaces;
+using Mud.Server.Domain.Attributes;
+using Mud.Server.Interfaces.Affect.Character;
+using Mud.Server.Interfaces.Character;
+
+namespace Mud.Server.Affects.Character;
+
+[Affect("CharacterBodyPartsAffect", typeof(CharacterBodyPartsAffectData))]
+public class CharacterBodyPartsAffect : FlagsAffectBase<IBodyParts>, ICharacterBodyPartsAffect
+{
+    protected override string Target => "Body parts";
+
+    public void Initialize(CharacterBodyPartsAffectData data)
+    {
+        Operator = data.Operator;
+        Modifier = new BodyParts(data.Modifier);
+    }
+
+    public void Apply(ICharacter character)
+    {
+        character.ApplyAffect(this);
+    }
+
+    public override AffectDataBase MapAffectData()
+    {
+        return new CharacterBodyPartsAffectData
+        {
+            Operator = Operator,
+            Modifier = Modifier.Serialize()
+        };
+    }
+}

--- a/Server/Mud.Server.Affects/Character/CharacterBodyPartsAffectData.cs
+++ b/Server/Mud.Server.Affects/Character/CharacterBodyPartsAffectData.cs
@@ -1,0 +1,13 @@
+﻿using Mud.Common.Attributes;
+using Mud.Domain.SerializationData.Avatar;
+using Mud.Server.Domain;
+
+namespace Mud.Server.Affects.Character;
+
+[JsonBaseType(typeof(AffectDataBase), "bodyParts")]
+public class CharacterBodyPartsAffectData : AffectDataBase
+{
+    public required AffectOperators Operator { get; set; } // Add and Or are identical
+
+    public required string Modifier { get; set; }
+}

--- a/Server/Mud.Server.Affects/Character/CharacterRaceAffect.cs
+++ b/Server/Mud.Server.Affects/Character/CharacterRaceAffect.cs
@@ -1,0 +1,46 @@
+﻿using Mud.Common;
+using Mud.Domain.SerializationData.Avatar;
+using Mud.Server.Domain.Attributes;
+using Mud.Server.Interfaces.Affect.Character;
+using Mud.Server.Interfaces.Character;
+using Mud.Server.Race.Interfaces;
+using System.Text;
+
+namespace Mud.Server.Affects.Character;
+
+[Affect("CharacterRaceAffect", typeof(CharacterRaceAffectData))]
+public class CharacterRaceAffect : ICharacterRaceAffect
+{
+    private IRaceManager RaceManager { get; }
+
+    public IRace Race { get; set; } = null!;
+
+    public CharacterRaceAffect(IRaceManager raceManager)
+    {
+        RaceManager = raceManager;
+    }
+
+    public void Initialize(CharacterRaceAffectData data)
+    {
+        var race = RaceManager[data.Race] ?? RaceManager.PlayableRaces.First();
+        Race = race;
+    }
+
+    public void Append(StringBuilder sb)
+    {
+        sb.AppendFormat("%c%modifies %y%Race %c%by setting to %y%{0}%x%", Race.Name.ToPascalCase());
+    }
+
+    public void Apply(ICharacter character)
+    {
+        character.ApplyAffect(this);
+    }
+
+    public AffectDataBase MapAffectData()
+    {
+        return new CharacterRaceAffectData
+        {
+            Race = Race.Name
+        };
+    }
+}

--- a/Server/Mud.Server.Affects/Character/CharacterRaceAffectData.cs
+++ b/Server/Mud.Server.Affects/Character/CharacterRaceAffectData.cs
@@ -1,0 +1,10 @@
+﻿using Mud.Common.Attributes;
+using Mud.Domain.SerializationData.Avatar;
+
+namespace Mud.Server.Affects.Character;
+
+[JsonBaseType(typeof(AffectDataBase), "race")]
+public class CharacterRaceAffectData : AffectDataBase
+{
+    public required string Race { get; set; }
+}

--- a/Server/Mud.Server.Commands.Admin/Information/Cstat.cs
+++ b/Server/Mud.Server.Commands.Admin/Information/Cstat.cs
@@ -116,7 +116,7 @@ public class Cstat : AdminGameAction
         sb.AppendFormatLine("Position: {0} GCD:{1} Daze:{2} Stunned: {3}", Whom.Position, Whom.GlobalCooldown, Whom.Daze, Whom.Stun);
         sb.AppendFormatLine("Furniture: {0}", Whom.Furniture?.DisplayName ?? "(none)");
         sb.AppendFormatLine("Room: {0} [vnum: {1}]", Whom.Room?.DisplayName ?? "(none)", Whom.Room?.Blueprint.Id ?? -1);
-        sb.AppendFormatLine("Race: {0} Class: {1}", Whom.Race?.DisplayName ?? "(none)", Whom.Classes.DisplayName());
+        sb.AppendFormatLine("Race: {0} (base: {1}) Class: {2}", Whom.Race?.DisplayName ?? "(none)", Whom.BaseRace?.DisplayName ?? "(none)", Whom.Classes.DisplayName());
         sb.AppendFormatLine("Sex: {0} (base: {1})", Whom.Sex, Whom.BaseSex);
         sb.AppendFormatLine("Size: {0} (base: {1})", Whom.Size, Whom.BaseSize);
         sb.AppendFormatLine("Silver: {0} Gold: {1}", Whom.SilverCoins, Whom.GoldCoins);

--- a/Server/Mud.Server.Commands.Character/Information/Equipment.cs
+++ b/Server/Mud.Server.Commands.Character/Information/Equipment.cs
@@ -26,7 +26,7 @@ public class Equipment : CharacterGameAction
             var countOffHandToHide = Actor.Size >= Sizes.Giant 
                 ? 0
                 : Actor.Equipments.Count(x => x.Slot == EquipmentSlots.MainHand && x.Item?.WearLocation == WearLocations.Wield2H);
-            foreach (var equippedItem in Actor.Equipments)
+            foreach (var equippedItem in Actor.Equipments.OrderBy(x => x.Slot))
             {
                 // don't display offhand if they are used to wield a 2H weapon
                 if (equippedItem.Item == null && equippedItem.Slot == EquipmentSlots.OffHand)

--- a/Server/Mud.Server.Commands.Character/Social/Socials.cs
+++ b/Server/Mud.Server.Commands.Character/Social/Socials.cs
@@ -32,6 +32,8 @@ public class Socials : CharacterGameAction
             if (++col % 5 == 0)
                 sb.AppendLine();
         }
+        if (col % 5 != 0)
+            sb.AppendLine();
         Actor.Page(sb);
     }
 }

--- a/Server/Mud.Server.Commands.PlayableCharacter/Attribute/Train.cs
+++ b/Server/Mud.Server.Commands.PlayableCharacter/Attribute/Train.cs
@@ -73,7 +73,7 @@ public class Train : PlayableCharacterGameAction
         if (attributeFound != null)
         {
             BasicAttributes attribute = attributeFound.attribute;
-            var max = GetMaxAttributeValue(attribute, Actor.Race as IPlayableRace, Actor.Classes);
+            var max = GetMaxAttributeValue(attribute, Actor.BaseRace as IPlayableRace, Actor.Classes);
             if (Actor.BaseAttribute((CharacterAttributes)attribute) >= max)
                 return $"Your {attributeFound.name} is already at maximum.";
             Cost = 1;

--- a/Server/Mud.Server.Interfaces/Affect/Character/ICharacterBodyFormsAffect.cs
+++ b/Server/Mud.Server.Interfaces/Affect/Character/ICharacterBodyFormsAffect.cs
@@ -1,0 +1,7 @@
+﻿using Mud.Flags.Interfaces;
+
+namespace Mud.Server.Interfaces.Affect.Character;
+
+public interface ICharacterBodyFormsAffect : IFlagsAffect<IBodyForms>, ICharacterAffect
+{
+}

--- a/Server/Mud.Server.Interfaces/Affect/Character/ICharacterBodyPartsAffect.cs
+++ b/Server/Mud.Server.Interfaces/Affect/Character/ICharacterBodyPartsAffect.cs
@@ -1,0 +1,7 @@
+﻿using Mud.Flags.Interfaces;
+
+namespace Mud.Server.Interfaces.Affect.Character;
+
+public interface ICharacterBodyPartsAffect : IFlagsAffect<IBodyParts>, ICharacterAffect
+{
+}

--- a/Server/Mud.Server.Interfaces/Affect/Character/ICharacterRaceAffect.cs
+++ b/Server/Mud.Server.Interfaces/Affect/Character/ICharacterRaceAffect.cs
@@ -1,0 +1,8 @@
+﻿using Mud.Server.Race.Interfaces;
+
+namespace Mud.Server.Interfaces.Affect.Character;
+
+public interface ICharacterRaceAffect : ICharacterAffect
+{
+    IRace Race { get; }
+}

--- a/Server/Mud.Server.Interfaces/Character/ICharacter.cs
+++ b/Server/Mud.Server.Interfaces/Character/ICharacter.cs
@@ -77,6 +77,7 @@ public interface ICharacter : IEntity, IContainer
 
     // Class/Race
     IEnumerable<IClass> Classes { get; }
+    IRace BaseRace { get; }
     IRace Race { get; }
 
     // Attributes/Resources/Flags
@@ -245,6 +246,9 @@ public interface ICharacter : IEntity, IContainer
     void ApplyAffect(ICharacterSexAffect affect);
     void ApplyAffect(ICharacterSizeAffect affect);
     void ApplyAffect(ICharacterResourceAffect affect);
+    void ApplyAffect(ICharacterRaceAffect affect);
+    void ApplyAffect(ICharacterBodyFormsAffect affect);
+    void ApplyAffect(ICharacterBodyPartsAffect affect);
 
     //
     void OnRemoved(IRoom nullRoom);

--- a/Server/Mud.Server.POC/Races/Doppleganger.cs
+++ b/Server/Mud.Server.POC/Races/Doppleganger.cs
@@ -1,0 +1,83 @@
+﻿using Microsoft.Extensions.Logging;
+using Mud.Common.Attributes;
+using Mud.Domain;
+using Mud.Flags;
+using Mud.Flags.Interfaces;
+using Mud.Server.Ability.Interfaces;
+using Mud.Server.Class.Interfaces;
+using Mud.Server.Domain;
+using Mud.Server.Race;
+using Mud.Server.Race.Interfaces;
+
+namespace Mud.Server.POC.Races;
+
+[Export(typeof(IRace)), Shared]
+public class Doppleganger : PlayableRaceBase
+{
+    public Doppleganger(ILogger<Insectoid> logger, IAbilityManager abilityManager)
+       : base(logger, abilityManager)
+    {
+        AddNaturalAbility("Morph", 0);
+    }
+
+    #region IRace
+
+    public override IEnumerable<EquipmentSlots> EquipmentSlots =>
+    [
+        Mud.Domain.EquipmentSlots.Float,
+    ];
+
+    public override string Name => "doppleganger";
+    public override string ShortName => "Dop";
+
+    public override Sizes Size => Sizes.Medium;
+    public override ICharacterFlags CharacterFlags => new CharacterFlags();
+
+    public override IIRVFlags Immunities => new IRVFlags();
+    public override IIRVFlags Resistances => new IRVFlags();
+    public override IIRVFlags Vulnerabilities => new IRVFlags();
+
+    public override IBodyForms BodyForms => new BodyForms("magical", "sentient");
+    public override IBodyParts BodyParts => new BodyParts();
+
+    public override IActFlags ActFlags => new ActFlags();
+    public override IOffensiveFlags OffensiveFlags => new OffensiveFlags();
+    public override IAssistFlags AssistFlags => new AssistFlags();
+
+    public override bool SelectableDuringCreation => false;
+    public override int CreationPointsStartValue => 20;
+
+    public override int GetStartAttribute(BasicAttributes attribute)
+    {
+        switch (attribute)
+        {
+            case BasicAttributes.Strength: return 10;
+            case BasicAttributes.Intelligence: return 10;
+            case BasicAttributes.Wisdom: return 10;
+            case BasicAttributes.Dexterity: return 10;
+            case BasicAttributes.Constitution: return 10;
+            default:
+                Logger.LogError("Unexpected start attribute {attribute} for {name}", attribute, Name);
+                return 0;
+        }
+    }
+
+    public override int GetMaxAttribute(BasicAttributes attribute)
+    {
+        switch (attribute)
+        {
+            case BasicAttributes.Strength: return 18;
+            case BasicAttributes.Intelligence: return 18;
+            case BasicAttributes.Wisdom: return 18;
+            case BasicAttributes.Dexterity: return 18;
+            case BasicAttributes.Constitution: return 18;
+            default:
+                Logger.LogError("Unexpected max attribute {attribute} for {name}", attribute, Name);
+                return 0;
+        }
+    }
+
+    public override int ClassExperiencePercentageMultiplier(IClass? c) => 250;
+
+    #endregion
+}

--- a/Server/Mud.Server.POC/Skills/BearForm.cs
+++ b/Server/Mud.Server.POC/Skills/BearForm.cs
@@ -46,7 +46,7 @@ public class BearForm : NoTargetSkillBase
         User.UpdateResource(ResourceKinds.Rage, 100); // TODO: should be 0
 
         // TODO: Affect changing Form + disable other form
-        AuraManager.AddAura(User, SkillName, User, User.Level, new AuraFlags("NoDispel", "Permanent", "Shapeshift"), true,
+        AuraManager.AddAura(User, SkillName, User, User.Level, new AuraFlags("NoDispel", "Permanent", "Shapeshift", "NoSave"), true,
             new CharacterAttributeAffect { Location = CharacterAttributeAffectLocations.AllArmor, Modifier = -User.Level * 5, Operator = AffectOperators.Add },
             new CharacterAttributeAffect { Location = CharacterAttributeAffectLocations.Constitution, Modifier = User.Level / 10, Operator = AffectOperators.Add },
             new CharacterResourceAffect { Location = ResourceKinds.HitPoints, Modifier = User.Level * 5, Operator = AffectOperators.Add },

--- a/Server/Mud.Server.POC/Skills/CatForm.cs
+++ b/Server/Mud.Server.POC/Skills/CatForm.cs
@@ -49,7 +49,7 @@ public class CatForm : NoTargetSkillBase
         User.SetResource(ResourceKinds.Combo, 0);
 
         // TODO: Affect changing Form + disable other form
-        AuraManager.AddAura(User, SkillName, User, User.Level, new AuraFlags("NoDispel", "Permanent", "Shapeshift"), true,
+        AuraManager.AddAura(User, SkillName, User, User.Level, new AuraFlags("NoDispel", "Permanent", "Shapeshift", "NoSave"), true,
             new CharacterAttributeAffect { Location = CharacterAttributeAffectLocations.DamRoll, Modifier = User.Level * 4, Operator = AffectOperators.Add },
             new CharacterFlagsAffect { Modifier = new CharacterFlags("Haste", "Infrared"), Operator = AffectOperators.Add });
 

--- a/Server/Mud.Server.POC/Skills/Morph.cs
+++ b/Server/Mud.Server.POC/Skills/Morph.cs
@@ -1,0 +1,85 @@
+﻿using Microsoft.Extensions.Logging;
+using Mud.Common;
+using Mud.Flags;
+using Mud.Random;
+using Mud.Server.Ability.Skill;
+using Mud.Server.Ability.Skill.Interfaces;
+using Mud.Server.Affects.Character;
+using Mud.Server.Domain;
+using Mud.Server.Domain.Attributes;
+using Mud.Server.Guards.CharacterGuards;
+using Mud.Server.Guards.Interfaces;
+using Mud.Server.Interfaces.Aura;
+using Mud.Server.Interfaces.Character;
+using Mud.Server.Race.Interfaces;
+
+namespace Mud.Server.POC.Skills;
+
+[CharacterCommand("morph", "Ability", "Buff", "Shapeshift", "POC")]
+[Skill(SkillName, AbilityEffects.Buff, PulseWaitTime = 20)]
+public class Morph : SkillBase
+{
+    private const string SkillName = "Morph";
+
+    private static readonly string[] Vowels = ["a", "e", "i", "o", "u", "y"];
+
+    private IAuraManager AuraManager { get; }
+    private IRaceManager RaceManager { get; }
+
+    public Morph(ILogger<BearForm> logger, IRandomManager randomManager, IAuraManager auraManager, IRaceManager raceManager)
+        : base(logger, randomManager)
+    {
+        AuraManager = auraManager;
+        RaceManager = raceManager;
+    }
+
+    protected override IGuard<ICharacter>[] Guards => [new CannotBeInCombat()];
+
+    protected override bool MustBeLearned => true;
+
+    protected override string? SetTargets(ISkillActionInput skillActionInput)
+    {
+        if (skillActionInput.Parameters.Length == 0)
+            Race = null;
+        else
+        {
+            var race = RaceManager.PlayableRaces.FirstOrDefault(x => StringCompareHelpers.StringStartsWith(x.Name, skillActionInput.Parameters[0].Value));
+            if (race == null)
+                return "This is not a valid race";
+            Race = race;
+        }
+        return null;
+    }
+
+    private IPlayableRace? Race { get; set; }
+
+    protected override bool Invoke()
+    {
+        if (Race == null)
+        {
+            User.Send("%W%You regain your original form%x%");
+            User.Act(ActOptions.ToRoom, "%W%{0:N} regains {0:s} original form.%x%", this);
+            User.RemoveAuras(x => StringCompareHelpers.StringEquals(x.AbilityName, SkillName), true, false);
+            return true;
+        }
+
+        // TODO: better wording
+        var article = Vowels.Any(Race.DisplayName.StartsWith)
+            ? "an"
+            : "a";
+        User.Send($"%W%You morph into {article} {Race.DisplayName}.%x%");
+        User.Act(ActOptions.ToRoom, "%W%{0:N} morphs into {1} {2}.%x%", this, article, Race.DisplayName);
+
+        AuraManager.AddAura(User, SkillName, User, User.Level, new AuraFlags("NoDispel", "Permanent", "Shapeshift"), true,
+            new CharacterRaceAffect(RaceManager) { Race = Race },
+            new CharacterSizeAffect { Value = Race.Size },
+            new CharacterFlagsAffect { Modifier = Race.CharacterFlags, Operator = AffectOperators.Assign },
+            new CharacterIRVAffect { Location = IRVAffectLocations.Immunities, Modifier = Race.Immunities, Operator = AffectOperators.Assign },
+            new CharacterIRVAffect { Location = IRVAffectLocations.Resistances, Modifier = Race.Resistances, Operator = AffectOperators.Assign },
+            new CharacterIRVAffect { Location = IRVAffectLocations.Vulnerabilities, Modifier = Race.Vulnerabilities, Operator = AffectOperators.Assign },
+            new CharacterBodyFormsAffect { Modifier = Race.BodyForms, Operator = AffectOperators.Assign },
+            new CharacterBodyPartsAffect { Modifier = Race.BodyParts, Operator = AffectOperators.Assign });
+
+        return true;
+    }
+}

--- a/Server/Mud.Server/Entity/EntityBase.cs
+++ b/Server/Mud.Server/Entity/EntityBase.cs
@@ -243,7 +243,7 @@ public abstract class EntityBase : ActorBase, IEntity
     protected AuraData[] MapAuraData()
     {
         // don't save Shapeshift neither NoSave
-        return Auras.Where(x => x.IsValid && !x.AuraFlags.IsSet("Shapeshift") && !x.AuraFlags.IsSet("NoSave")).Select(x => x.MapAuraData()).ToArray();
+        return Auras.Where(x => x.IsValid && !x.AuraFlags.IsSet("NoSave")).Select(x => x.MapAuraData()).ToArray();
     }
 
     protected static TFlags NewAndCopyAndSet<TFlags>(Func<TFlags> newFunc, TFlags? toCopy, TFlags? toSet)

--- a/Server/Mud.Server/Player/Player.cs
+++ b/Server/Mud.Server/Player/Player.cs
@@ -227,7 +227,7 @@ public class Player : ActorBase, IPlayer
         avatarMetaData.Version = Versioning.AvatarCurrentVersion;
         avatarMetaData.Level = Impersonating.Level;
         avatarMetaData.Classes = Impersonating.Classes.Select(x => x.DisplayName).ToArray();
-        avatarMetaData.Race = Impersonating.Race.DisplayName;
+        avatarMetaData.Race = Impersonating.BaseRace.DisplayName;
         avatarMetaData.RoomId = Impersonating.Room.Blueprint.Id;
     }
 

--- a/TODO.txt
+++ b/TODO.txt
@@ -1,12 +1,19 @@
 INGOING
 DONE
-    multiple managers fixed to used StringComparer.InvariantCultureIgnoreCase in dictionary
-    Floating disc fixed
-    Rom import door exit flags fixed
-    AbilityDefinition.Name used instead of SpellName/SkillName in spells/skills when adding aura
-    Absorb affect
-    when immune to damage, the phrase displayed is weird
-        XXX is immune to your misses
+    base/current race
+    affect to modify race
+    BuildEquipmentSlots depends on current race
+        create/remove only missing/invalid slot
+    ExperienceByLevel, GetMaxAttribute, RecomputeKnownAbilities, MaxAllowedBasicAttribute: use base (and not current)
+    Initialize
+        equip as much items as possible with default equipment slots, keeping a list of unequipable items
+        recompute race and equipment slots
+        try to equip items that were unequipable in previous equip try
+            if cannot equip -> display already existing Wiznet
+        LearnedAbilities PlayableRace.Abilities
+    CharacterBodyFormsAffect, CharacterBodyPartsAffect
+    morph command (race+aff+irv+body+size, act/off/assist ?)
+    bug fixed in ApplyAffect(ICharacterIRVAffect affect) vulnerabilities affects were applied on resistances instead of vulnerabilities
 
 ==========
 == TODO ==


### PR DESCRIPTION
    base/current race
    affect to modify race
    BuildEquipmentSlots depends on current race
        create/remove only missing/invalid slot
    ExperienceByLevel, GetMaxAttribute, RecomputeKnownAbilities, MaxAllowedBasicAttribute: use base (and not current)
    Initialize
        equip as much items as possible with default equipment slots, keeping a list of unequipable items
        recompute race and equipment slots
        try to equip items that were unequipable in previous equip try
            if cannot equip -> display already existing Wiznet
        LearnedAbilities PlayableRace.Abilities
    CharacterBodyFormsAffect, CharacterBodyPartsAffect
    morph command (race+aff+irv+body+size, act/off/assist ?)
    bug fixed in ApplyAffect(ICharacterIRVAffect affect) vulnerabilities affects were applied on resistances instead of vulnerabilities
close #307 